### PR TITLE
signup method throws an error instead of returning null user and sess…

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -418,8 +418,10 @@ export default class GoTrueClient {
 
       const { data, error } = res
 
+  
+      
       if (error || !data) {
-        return { data: { user: null, session: null }, error: error }
+        throw new Error(error?.message || 'auth/invalid-response')
       }
 
       const session: Session | null = data.session


### PR DESCRIPTION
## What kind of change does this PR introduce?

minor change to the signup method

## What is the current behavior?

for error responses auth.signUp returned `{ data: { user: null, session: null }, error: error } `

## What is the new behavior?

for error responses auth.signUp throws an error.


