### PR TITLE
fix: provide statusText as error message on retryable network errors

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -42,7 +42,7 @@ async function handleError(error: unknown) {
 
   if (NETWORK_ERROR_CODES.includes(error.status)) {
     // status in 500...599 range - server had an error, request might be retryed.
-    throw new AuthRetryableFetchError(_getErrorMessage(error), error.status)
+    throw new AuthRetryableFetchError(error.statusText, error.status)
   }
 
   let data: any

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -105,6 +105,26 @@ describe('fetch', () => {
       await server.start()
     })
 
+    test('should throw AuthRetryableFetchError when response is a network error', async () => {
+      const route = server
+        .get('/')
+        .mockImplementationOnce((ctx) => {
+          ctx.status = 504
+          ctx.statusText = 'Gateway Timeout'
+          ctx.body = 'Gateway Timeout'
+        })
+        .mockImplementation((ctx) => {
+          ctx.status = 200
+        })
+
+      const url = server.getURL().toString()
+      const result = _request(fetch, 'GET', url)
+      await expect(result).rejects.toBeInstanceOf(AuthRetryableFetchError)
+      await expect(result).rejects.toMatchObject({ status: 504, message: 'Gateway Timeout' })
+
+      expect(route).toHaveBeenCalledTimes(1)
+    })
+
     test('should work with custom fetch implementation', async () => {
       const customFetch = (async () => {
         return {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes a minor, but annoying lack of error message and adds a test case for an uncovered branch.

## What is the current behavior?
Network errors (502,503,504) result into `AuthRetryableFetchError` (correct), with `"{}"` as an `Error#message` (embarassing if displayed to the end user). 

![Screenshot of an error in the console](https://github.com/supabase/gotrue-js/assets/79251424/749bd403-ba53-4fa2-b5f7-2bcc379af4f7)

The bug is caused by erroneous usage of `_getErrorMessage(error)` helper in a branch where `looksLikeFetchResponse(error)` assertion have succeeded and `error.status` is `502 | 503 | 504`. I believe `_getErrorMessage` was intended to be called on something that has been thrown or returned as an error, not on a resolved fetch response that was not `ok`. 

The dreaded `"{}"` comes from the final `JSON.stringify` fallback of `_getErrorMessage`.

## What is the new behavior?

I went for the simplest solution of providing `Response.statusText` property as an error message. Status text is the only human-readable piece of information that is reliably/readily available in this context. It is also reasonable to expect it to be clear and accurate.

## Additional context

I briefly considered pulling in the `Response.text()` and including it in the message, but decided against it. Proxy errors rarely include any extra info there, but often include HTML formatting and styling which wouldn't be appropriate here. Also waiting for `Response.text()` might fail with another error.

This fix should be backwards compatible on a patch level. The `Error` constructor coerces the message to a String (or leaves out an empty string in case of `undefined`) therefore even in case of custom fetch implementations/middlewares that don't provide `statusText` our `AuthRetryableFetchError` will still have a `message` field of a string type.