### PR TITLE
feat: add kakao to sign in with ID token

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -572,8 +572,8 @@ export type SignInWithOAuthCredentials = {
 }
 
 export type SignInWithIdTokenCredentials = {
-  /** Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `keycloak` (deprecated). */
-  provider: 'google' | 'apple' | 'azure' | 'facebook' | string
+  /** Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `kakao`, `keycloak` (deprecated). */
+  provider: 'google' | 'apple' | 'azure' | 'facebook' | 'kakao' | string
   /** OIDC ID token issued by the specified provider. The `iss` claim in the ID token must match the supplied provider. Some ID tokens contain an `at_hash` which require that you provide an `access_token` value to be accepted properly. If the token contains a `nonce` claim you must supply the nonce used to obtain the ID token. */
   token: string
   /** If the ID token contains an `at_hash` claim, then the hash of this value is compared to the value in the ID token. */


### PR DESCRIPTION
Adds the `kakao` string to the supported `signInWithIdToken` types.

Merge after: https://github.com/supabase/gotrue/pull/1381