### PR TITLE
fix: add memory leak warning to `GoTrueClient` for unsupported runtimes

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2077,6 +2077,7 @@ export default class GoTrueClient {
     const ticker = setInterval(() => this._autoRefreshTokenTick(), AUTO_REFRESH_TICK_DURATION)
     this.autoRefreshTicker = ticker
 
+    let willUnref = false
     if (ticker && typeof ticker === 'object' && typeof ticker.unref === 'function') {
       // ticker is a NodeJS Timeout object that has an `unref` method
       // https://nodejs.org/api/timers.html#timeoutunref
@@ -2085,12 +2086,18 @@ export default class GoTrueClient {
       // finished and tests run endlessly. This can be prevented by calling
       // `unref()` on the returned object.
       ticker.unref()
+      willUnref = true
       // @ts-ignore
     } else if (typeof Deno !== 'undefined' && typeof Deno.unrefTimer === 'function') {
       // similar like for NodeJS, but with the Deno API
       // https://deno.land/api@latest?unstable&s=Deno.unrefTimer
       // @ts-ignore
       Deno.unrefTimer(ticker)
+      willUnref = true
+    }
+
+    if(!willUnref) {
+      console.warn("[GoTrueClient] dereferencing setInterval is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856");
     }
 
     // run the tick immediately, but in the next pass of the event loop so that

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -118,8 +118,6 @@ export default class GoTrueClient {
 
   private instanceID: number
 
-  private static memoryLeakWarningIssued: boolean = false;
-
   /**
    * Namespace for the GoTrue admin methods.
    * These methods should only be used in a trusted server-side environment.
@@ -170,6 +168,7 @@ export default class GoTrueClient {
   protected logger: (message: string, ...args: any[]) => void = console.log
 
   protected insecureGetSessionWarningShown = false
+  private static memoryLeakWarningIssued = false
 
   /**
    * Create a new client for use in the browser.

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -118,6 +118,8 @@ export default class GoTrueClient {
 
   private instanceID: number
 
+  private static memoryLeakWarningIssued: boolean = false;
+
   /**
    * Namespace for the GoTrue admin methods.
    * These methods should only be used in a trusted server-side environment.
@@ -2096,8 +2098,9 @@ export default class GoTrueClient {
       willUnref = true
     }
 
-    if(!willUnref) {
+    if(!willUnref && !GoTrueClient.memoryLeakWarningIssued) { // prevents the warning from being spammed / shown multiple times
       console.warn("[GoTrueClient] dereferencing setInterval is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856");
+      GoTrueClient.memoryLeakWarningIssued = true;
     }
 
     // run the tick immediately, but in the next pass of the event loop so that

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2098,8 +2098,8 @@ export default class GoTrueClient {
     }
 
     if(!willUnref && !GoTrueClient.memoryLeakWarningIssued) { // prevents the warning from being spammed / shown multiple times
-      console.warn("[GoTrueClient] dereferencing setInterval is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856");
-      GoTrueClient.memoryLeakWarningIssued = true;
+      console.warn("[GoTrueClient] dereferencing `setInterval` is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856")
+      GoTrueClient.memoryLeakWarningIssued = true
     }
 
     // run the tick immediately, but in the next pass of the event loop so that

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -168,7 +168,7 @@ export default class GoTrueClient {
   protected logger: (message: string, ...args: any[]) => void = console.log
 
   protected insecureGetSessionWarningShown = false
-  private static memoryLeakWarningIssued = false
+  private static memoryLeakWarningShown = false
 
   /**
    * Create a new client for use in the browser.
@@ -2097,9 +2097,9 @@ export default class GoTrueClient {
       willUnref = true
     }
 
-    if(!willUnref && !GoTrueClient.memoryLeakWarningIssued) { // prevents the warning from being spammed / shown multiple times
+    if(!willUnref && !GoTrueClient.memoryLeakWarningShown) { // prevents the warning from being spammed / shown multiple times
       console.warn("[GoTrueClient] dereferencing `setInterval` is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856")
-      GoTrueClient.memoryLeakWarningIssued = true
+      GoTrueClient.memoryLeakWarningShown = true
     }
 
     // run the tick immediately, but in the next pass of the event loop so that

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2097,7 +2097,7 @@ export default class GoTrueClient {
       willUnref = true
     }
 
-    if(!willUnref && !GoTrueClient.memoryLeakWarningShown) { // prevents the warning from being spammed / shown multiple times
+    if(!willUnref && !GoTrueClient.memoryLeakWarningShown && (typeof isBrowser !== "function" || !isBrowser())) { // prevents the warning from being spammed / shown multiple times
       console.warn("[GoTrueClient] dereferencing `setInterval` is not supported in your JavaScript Runtime. This will cause memory leaks unless you call the `stopAutoRefresh` method before losing the last reference to a `GoTrueClient` instance. If you are using `supabase-js`, this can be accomplished by calling `supabase.auth.stopAutoRefresh()`. For more information, see https://github.com/supabase/gotrue-js/issues/856")
       GoTrueClient.memoryLeakWarningShown = true
     }


### PR DESCRIPTION
Adds a warning regarding memory leaks in some javascript runtimes that do not support `setInterval` dereferencing (allowing users to better/manually clean-up supabase instances, freeing memory and allowing for garbage collection)

## What kind of change does this PR introduce?

Warning/bug fix

## What is the current behavior?

Currently, in environments that are neither `Node.js` nor `Deno`, a memory leak occurs due to `setInterval` not being dereferenced. See https://github.com/supabase/gotrue-js/issues/856. The implementor is never warned that such a memory leak exists for their specific runtime (such as in React Native). 

This implements a warning, at least, that fires only once, to notify implementors to better clean-up instances in their environments (such as manually calling `stopAutoRefresh` when ready to dispose of instances).

## What is the new behavior?

Noted above.

## Additional context

https://github.com/supabase/gotrue-js/issues/856