### PR TITLE
fix: implement exponential back off on the retries of `_refreshAccessToken` method

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1812,7 +1812,7 @@ export default class GoTrueClient {
       // will attempt to refresh the token with exponential backoff
       return await retryable(
         async (attempt) => {
-          await sleep(Math.pow(200, attempt)) // 0, 200, 400, 800, ...
+          await sleep(100 * Math.pow(2, attempt)) // 0, 200, 400, 800, ...
 
           this._debug(debugName, 'refreshing attempt', attempt)
 
@@ -1827,7 +1827,7 @@ export default class GoTrueClient {
           result.error &&
           isAuthRetryableFetchError(result.error) &&
           // retryable only if the request can be sent before the backoff overflows the tick duration
-          Date.now() + Math.pow(200, attempt + 1) - startedAt < AUTO_REFRESH_TICK_DURATION
+          Date.now() + 200 * Math.pow(2, attempt + 1) - startedAt < AUTO_REFRESH_TICK_DURATION
       )
     } catch (error) {
       this._debug(debugName, 'error', error)

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1812,7 +1812,7 @@ export default class GoTrueClient {
       // will attempt to refresh the token with exponential backoff
       return await retryable(
         async (attempt) => {
-          await sleep(attempt * 200) // 0, 200, 400, 800, ...
+          await sleep(Math.pow(200, attempt)) // 0, 200, 400, 800, ...
 
           this._debug(debugName, 'refreshing attempt', attempt)
 
@@ -1827,7 +1827,7 @@ export default class GoTrueClient {
           result.error &&
           isAuthRetryableFetchError(result.error) &&
           // retryable only if the request can be sent before the backoff overflows the tick duration
-          Date.now() + (attempt + 1) * 200 - startedAt < AUTO_REFRESH_TICK_DURATION
+          Date.now() + Math.pow(200, attempt + 1) - startedAt < AUTO_REFRESH_TICK_DURATION
       )
     } catch (error) {
       this._debug(debugName, 'error', error)

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1812,7 +1812,7 @@ export default class GoTrueClient {
       // will attempt to refresh the token with exponential backoff
       return await retryable(
         async (attempt) => {
-          await sleep(100 * Math.pow(2, attempt)) // 0, 200, 400, 800, ...
+          await sleep(200 * Math.pow(2, attempt)) // 0, 200, 400, 800, ...
 
           this._debug(debugName, 'refreshing attempt', attempt)
 

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1812,7 +1812,9 @@ export default class GoTrueClient {
       // will attempt to refresh the token with exponential backoff
       return await retryable(
         async (attempt) => {
-          await sleep(200 * Math.pow(2, attempt)) // 0, 200, 400, 800, ...
+          if (attempt > 0) {
+            await sleep(200 * Math.pow(2, attempt - 1)) // 200, 400, 800, ...
+          }
 
           this._debug(debugName, 'refreshing attempt', attempt)
 
@@ -1827,7 +1829,7 @@ export default class GoTrueClient {
           result.error &&
           isAuthRetryableFetchError(result.error) &&
           // retryable only if the request can be sent before the backoff overflows the tick duration
-          Date.now() + 200 * Math.pow(2, attempt + 1) - startedAt < AUTO_REFRESH_TICK_DURATION
+          Date.now() + 200 * Math.pow(2, attempt) - startedAt < AUTO_REFRESH_TICK_DURATION
       )
     } catch (error) {
       this._debug(debugName, 'error', error)

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1824,12 +1824,11 @@ export default class GoTrueClient {
             xform: _sessionResponse,
           })
         },
-        (attempt, _, result) => {
+        (attempt, error) => {
           const nextBackOffInterval = 200 * Math.pow(2, attempt)
           return (
-            result &&
-            result.error &&
-            isAuthRetryableFetchError(result.error) &&
+            error &&
+            isAuthRetryableFetchError(error) &&
             // retryable only if the request can be sent before the backoff overflows the tick duration
             Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION
           )

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1824,12 +1824,16 @@ export default class GoTrueClient {
             xform: _sessionResponse,
           })
         },
-        (attempt, _, result) =>
-          result &&
-          result.error &&
-          isAuthRetryableFetchError(result.error) &&
-          // retryable only if the request can be sent before the backoff overflows the tick duration
-          Date.now() + 200 * Math.pow(2, attempt) - startedAt < AUTO_REFRESH_TICK_DURATION
+        (attempt, _, result) => {
+          const nextBackOffInterval = 200 * Math.pow(2, attempt)
+          return (
+            result &&
+            result.error &&
+            isAuthRetryableFetchError(result.error) &&
+            // retryable only if the request can be sent before the backoff overflows the tick duration
+            Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION
+          )
+        }
       )
     } catch (error) {
       this._debug(debugName, 'error', error)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently the retry interval of `_refreshAccessToken` goes 200, 400, 600, 800, where as I believe the intended intervals are 200, 400, 800, 1600...

## What is the current behavior?

The retry interval is multiple of 200 ms.

## What is the new behavior?

The retry interval is properly set exponentially. 