### PR TITLE
chore: add missing 'is_anonymous' property to User type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -339,6 +339,7 @@ export interface User {
   role?: string
   updated_at?: string
   identities?: UserIdentity[]
+  is_anonymous: boolean
   factors?: Factor[]
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -339,7 +339,7 @@ export interface User {
   role?: string
   updated_at?: string
   identities?: UserIdentity[]
-  is_anonymous: boolean
+  is_anonymous?: boolean
   factors?: Factor[]
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Types update

## What is the current behavior?

User type is missing 'is_anonymous' property.

## What is the new behavior?

User type has the 'is_anonymous' property.

## Additional context

I'm not 100% certain if this property is optional or not, hoping @kangmingtay can offer some insight as they implemented the feature in https://github.com/supabase/auth/issues/68

Fixes https://github.com/supabase/auth-js/issues/872