### PR TITLE
fix: check for no error, instead of data, on insecure ssr getSession() warning

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1174,7 +1174,7 @@ export default class GoTrueClient {
       return await this._getUser()
     })
 
-    if (result.data && this.storage.isServer) {
+    if (!result.error && this.storage.isServer) {
       // no longer emit the insecure warning for getSession() as the access_token is now authenticated
       this.insecureGetSessionWarningShown = true
     }


### PR DESCRIPTION
Checks for no error instead of the presence of data when showing the warning about potential insecure use of `getSession()`.