### PR TITLE
fix: `getUser` returns null if there is no session

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1198,6 +1198,11 @@ export default class GoTrueClient {
           throw error
         }
 
+        if (!data.session?.access_token) {
+          // if there's no access token, the user can't be fetched
+          return { data: { user: null }, error: new AuthSessionMissingError() }
+        }
+
         return await _request(this.fetch, 'GET', `${this.url}/user`, {
           headers: this.headers,
           jwt: data.session?.access_token ?? undefined,


### PR DESCRIPTION
If there is no session (i.e. no JWT/access token), `getUser()` cannot possibly work. It now returns null user.

Previously, it just sent out a request _without the JWT_. When combined with `@supabase/supabase-js` which does some clever tricks with `fetch` by adding a default `Authorization` header using the Supabase `anon` API key, if you called `getUser()` at the wrong time an error such as `missing sub claim` error message would be thrown by Supabase Auth.

(Unfortunately the Supabase `anon` API key is signed with the same JWT secret, so it's hard to disambiguate why this is happening.)