### PR TITLE
fix: check for access token in header

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1174,7 +1174,8 @@ export default class GoTrueClient {
           throw error
         }
 
-        if (!data.session?.access_token) {
+        const hasAccessToken = data.session?.access_token || this.headers['Authorization']
+        if (!hasAccessToken) {
           // if there's no access token, the user can't be fetched
           return { data: { user: null }, error: new AuthSessionMissingError() }
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #881 
* https://github.com/supabase/auth-js/pull/876 introduced a breaking change in `getUser()` which resulted in the authorization header not being used 