### PR TITLE
fix: revert check for access token in header

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1174,8 +1174,7 @@ export default class GoTrueClient {
           throw error
         }
 
-        const hasAccessToken = data.session?.access_token || this.headers['Authorization']
-        if (!hasAccessToken) {
+        if (!data.session?.access_token) {
           // if there's no access token, the user can't be fetched
           return { data: { user: null }, error: new AuthSessionMissingError() }
         }


### PR DESCRIPTION
Reverts supabase/auth-js#882 due to

> One thing to keep in mind is that the Authorization header will always exist since the anon key is there by default, right? So hasAccessToken will always be true; which makes this whole section of code useless, and you might as well go back to no checks.
>
> One thing you could do when the client is created is check if the dev passed in an Authorization header. If so, set something like this.hasCustomAuthHeader = true - which would be intialized as false during client creation.
> 
> Then you could check for that on the right side of || in this getUser code.
