### PR TITLE
fix: Revert "fix: `getUser` returns null if there is no session (#876)"

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1174,11 +1174,6 @@ export default class GoTrueClient {
           throw error
         }
 
-        if (!data.session?.access_token) {
-          // if there's no access token, the user can't be fetched
-          return { data: { user: null }, error: new AuthSessionMissingError() }
-        }
-
         return await _request(this.fetch, 'GET', `${this.url}/user`, {
           headers: this.headers,
           jwt: data.session?.access_token ?? undefined,


### PR DESCRIPTION
This reverts commit 6adf8caa4ca803e65f943cc88a2849f5905a044a.

Revert check for access token before fetching user. While potentially beneficial, we'll need to update our guides and address a few other issues before we can proceed with this change