### PR TITLE
fix: re-add `getUser` returns null if there is no session

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1174,6 +1174,11 @@ export default class GoTrueClient {
           throw error
         }
 
+        if (!data.session?.access_token) {
+          // if there's no access token, the user can't be fetched
+          return { data: { user: null }, error: new AuthSessionMissingError() }
+        }
+
         return await _request(this.fetch, 'GET', `${this.url}/user`, {
           headers: this.headers,
           jwt: data.session?.access_token ?? undefined,


### PR DESCRIPTION
Reverts supabase/auth-js#889