### PR TITLE
fix: return error if missing session or missing custom auth header

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -100,6 +100,7 @@ const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage' |
   headers: DEFAULT_HEADERS,
   flowType: 'implicit',
   debug: false,
+  hasCustomAuthorizationHeader: false,
 }
 
 /** Current session will be checked for refresh at this interval. */
@@ -154,6 +155,7 @@ export default class GoTrueClient {
   protected headers: {
     [key: string]: string
   }
+  protected hasCustomAuthorizationHeader = false
   protected fetch: Fetch
   protected lock: LockFunc
   protected lockAcquired = false
@@ -202,6 +204,7 @@ export default class GoTrueClient {
     this.lock = settings.lock || lockNoOp
     this.detectSessionInUrl = settings.detectSessionInUrl
     this.flowType = settings.flowType
+    this.hasCustomAuthorizationHeader = settings.hasCustomAuthorizationHeader
 
     if (settings.lock) {
       this.lock = settings.lock
@@ -1172,6 +1175,11 @@ export default class GoTrueClient {
         const { data, error } = result
         if (error) {
           throw error
+        }
+
+        // returns an error if there is no access_token or custom authorization header
+        if (!data.session?.access_token && !this.hasCustomAuthorizationHeader) {
+          return { data: { user: null }, error: new AuthSessionMissingError() }
         }
 
         return await _request(this.fetch, 'GET', `${this.url}/user`, {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,7 +81,8 @@ export type GoTrueClientOptions = {
    */
   lock?: LockFunc
   /**
-   * Set to "true" if there is a custom authorization header
+   * Set to "true" if there is a custom authorization header set globally.
+   * @experimental
    */
   hasCustomAuthorizationHeader?: boolean
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,6 +80,10 @@ export type GoTrueClientOptions = {
    * @experimental
    */
   lock?: LockFunc
+  /**
+   * Set to "true" if there is a custom authorization header
+   */
+  hasCustomAuthorizationHeader?: boolean
 }
 
 export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a new property `hasCustomAuthorizationHeader` which will be set by supabase-js 
* `getUser` should return an `AuthSessionMissingError` if there is no session and no custom auth header is set
