### PR TITLE
fix: signOut should ignore 403s

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm off
-    image: supabase/auth:v2.129.0
+    image: supabase/auth:v2.150.1
     ports:
       - '9999:9999'
     environment:
@@ -42,7 +42,7 @@ services:
       - db
     restart: on-failure
   autoconfirm: # Signup enabled, autoconfirm on
-    image: supabase/auth:v2.129.0
+    image: supabase/auth:v2.150.1
     ports:
       - '9998:9998'
     environment:
@@ -71,7 +71,7 @@ services:
       - db
     restart: on-failure
   disabled: # Signup disabled
-    image: supabase/auth:v2.129.0
+    image: supabase/auth:v2.150.1
     ports:
       - '9997:9997'
     environment:
@@ -106,7 +106,7 @@ services:
       - '9000:9000' # web interface
       - '1100:1100' # POP3
   db:
-    image: supabase/postgres:14.1.0
+    image: supabase/postgres:15.1.1.46
     ports:
       - '5432:5432'
     command: postgres -c config_file=/etc/postgresql/postgresql.conf

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1571,7 +1571,12 @@ export default class GoTrueClient {
         if (error) {
           // ignore 404s since user might not exist anymore
           // ignore 401s since an invalid or expired JWT should sign out the current session
-          if (!(isAuthApiError(error) && (error.status === 404 || error.status === 401))) {
+          if (
+            !(
+              isAuthApiError(error) &&
+              (error.status === 404 || error.status === 401 || error.status === 403)
+            )
+          ) {
             return { error }
           }
         }

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -404,7 +404,8 @@ describe('GoTrueAdminApi', () => {
         })
 
         expect(user).toBeNull()
-        expect(error?.message).toEqual('User not found')
+        expect(error?.message).toEqual('Token has expired or is invalid')
+        expect(error?.status).toEqual(403)
       })
 
       test('verifyOTP() with invalid phone number', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* fixes https://github.com/supabase/auth/issues/1550 and https://github.com/supabase/auth/issues/1518
* update tests to use latest auth version

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
