### PR TITLE
fix: suppress getSession warning whenever _saveSession is called

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -156,6 +156,7 @@ export default class GoTrueClient {
     [key: string]: string
   }
   protected hasCustomAuthorizationHeader = false
+  protected suppressGetSessionWarning = false
   protected fetch: Fetch
   protected lock: LockFunc
   protected lockAcquired = false
@@ -1112,9 +1113,10 @@ export default class GoTrueClient {
 
       if (!hasExpired) {
         if (this.storage.isServer) {
+          const suppressWarning = this.suppressGetSessionWarning
           const proxySession: Session = new Proxy(currentSession, {
             get(target: any, prop: string, receiver: any) {
-              if (prop === 'user') {
+              if (!suppressWarning && prop === 'user') {
                 // only show warning when the user object is being accessed from the server
                 console.warn(
                   'Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and many not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.'
@@ -2023,7 +2025,9 @@ export default class GoTrueClient {
    */
   private async _saveSession(session: Session) {
     this._debug('#_saveSession()', session)
-
+    // _saveSession is always called whenever a new session has been acquired
+    // so we can safely suppress the warning returned by future getSession calls
+    this.suppressGetSessionWarning = true
     await setItemAsync(this.storage, this.storageKey, session)
   }
 

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -10,6 +10,7 @@ import {
   clientApiAutoConfirmDisabledClient as signUpDisabledClient,
   clientApiAutoConfirmEnabledClient as signUpEnabledClient,
   authAdminApiAutoConfirmEnabledClient,
+  GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
 } from './lib/clients'
 import { mockUserCredentials } from './lib/utils'
 
@@ -983,5 +984,34 @@ describe('GoTrueClient with storageisServer = true', () => {
         'Using the user object as returned from supabase.auth.getSession() '
       )
     ).toEqual(true)
+  })
+
+  test('getSession emits no warnings if getUser is called prior', async () => {
+    const client = new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      autoRefreshToken: false,
+      persistSession: true,
+      storage: {
+        ...memoryLocalStorageAdapter(),
+        isServer: true,
+      },
+    })
+    const { email, password } = mockUserCredentials()
+    await client.signUp({ email, password })
+
+    const {
+      data: { user },
+      error,
+    } = await client.getUser() // should suppress any warnings
+    expect(error).toBeNull()
+    expect(user).not.toBeNull()
+
+    const {
+      data: { session },
+    } = await client.getSession()
+
+    const sessionUser = session?.user // accessing the user object from getSession shouldn't emit a warning
+    expect(sessionUser).not.toBeNull()
+    expect(warnings.length).toEqual(0)
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?
* we can safely suppress the warning returned by `_getSession` whenever `_saveSession` is called - this further reduces the noise in #874 