### PR TITLE
chore: bump auth version in test

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm off
-    image: supabase/auth:v2.150.1
+    image: supabase/auth:v2.151.0
     ports:
       - '9999:9999'
     environment:
@@ -42,7 +42,7 @@ services:
       - db
     restart: on-failure
   autoconfirm: # Signup enabled, autoconfirm on
-    image: supabase/auth:v2.150.1
+    image: supabase/auth:v2.151.0
     ports:
       - '9998:9998'
     environment:
@@ -71,7 +71,7 @@ services:
       - db
     restart: on-failure
   disabled: # Signup disabled
-    image: supabase/auth:v2.150.1
+    image: supabase/auth:v2.151.0
     ports:
       - '9997:9997'
     environment:


### PR DESCRIPTION
## What kind of change does this PR introduce?
* bump the auth image used in tests to the latest version