### PR TITLE
feat: remove session, emit `SIGNED_OUT` when JWT `session_id` is invalid

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -11,6 +11,7 @@ import {
   isAuthApiError,
   isAuthError,
   isAuthRetryableFetchError,
+  isAuthSessionMissingError,
 } from './lib/errors'
 import {
   Fetch,
@@ -1194,6 +1195,15 @@ export default class GoTrueClient {
       })
     } catch (error) {
       if (isAuthError(error)) {
+        if (isAuthSessionMissingError(error)) {
+          // JWT contains a `session_id` which does not correspond to an active
+          // session in the database, indicating the user is signed out.
+
+          await this._removeSession()
+          await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+          await this._notifyAllSubscribers('SIGNED_OUT', null)
+        }
+
         return { data: { user: null }, error }
       }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,6 +69,10 @@ export class AuthSessionMissingError extends CustomAuthError {
   }
 }
 
+export function isAuthSessionMissingError(error: any): error is AuthSessionMissingError {
+  return isAuthError(error) && error.name === 'AuthSessionMissingError'
+}
+
 export class AuthInvalidTokenResponseError extends CustomAuthError {
   constructor() {
     super('Auth session or user missing', 'AuthInvalidTokenResponseError', 500, undefined)

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -14,6 +14,7 @@ import {
   AuthRetryableFetchError,
   AuthWeakPasswordError,
   AuthUnknownError,
+  AuthSessionMissingError,
 } from './errors'
 
 export type Fetch = typeof fetch
@@ -91,6 +92,11 @@ export async function handleError(error: unknown) {
       error.status,
       data.weak_password?.reasons || []
     )
+  } else if (errorCode === 'session_not_found') {
+    // The `session_id` inside the JWT does not correspond to a row in the
+    // `sessions` table. This usually means the user has signed out, has been
+    // deleted, or their session has somehow been terminated.
+    throw new AuthSessionMissingError()
   }
 
   throw new AuthApiError(_getErrorMessage(data), error.status || 500, errorCode)


### PR DESCRIPTION
When the access token (JWT) contains a `session_id` property which does not correspond to a row in the `sessions` table, it means that the user has been signed out or the session has been destroyed in some way. Auth will send back a `session_not_found` error code which can be detected by the client library and removing of the stored session with emitting the `SIGNED_OUT` event should take place.