### PR TITLE
don't use session.user object in _getAuthenticatorAssuranceLevel()

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2545,8 +2545,19 @@ export default class GoTrueClient {
 
         let nextLevel: AuthenticatorAssuranceLevels | null = currentLevel
 
+        const {
+          data: { user },
+          error: userError,
+        } = await this._getUser()
+        if (userError) {
+          return { data: null, error: userError }
+        }
+        if (!user) {
+          return { data: { currentLevel, nextLevel, currentAuthenticationMethods: [] }, error: null }
+        }
+        
         const verifiedFactors =
-          session.user.factors?.filter((factor: Factor) => factor.status === 'verified') ?? []
+          user.factors?.filter((factor: Factor) => factor.status === 'verified') ?? []
 
         if (verifiedFactors.length > 0) {
           nextLevel = 'aal2'


### PR DESCRIPTION
One avoidable source of the `getUser()` warnings

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Can't get rid of getUser() warning](https://github.com/supabase/auth-js/issues/873#issuecomment-2081467385)

## What is the new behavior?

The warning is no longer logged on the line defining `verifiedFactors`

## Additional context

N/A
