### PR TITLE
fix: type errors in verifyOtp

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -722,8 +722,8 @@ export default class GoTrueClient {
    */
   async verifyOtp(params: VerifyOtpParams): Promise<AuthResponse> {
     try {
-      let redirectTo = undefined
-      let captchaToken = undefined
+      let redirectTo: string | undefined = undefined
+      let captchaToken: string | undefined = undefined
       if ('options' in params) {
         redirectTo = params.options?.redirectTo
         captchaToken = params.options?.captchaToken


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The variables where having types undefined, but they should have the type string or undefined

## What is the new behavior?

Fixed the types for the variables
