### PR TITLE
fix: patch release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           if [ "$RELEASE_CANDIDATE" == "true" ]
           then
             DIST_TAG=rc
-          elif [ "$GITHUB_REF" == "refs/heads/main" ] && [ "$GITHUB_REF" == "refs/heads/master" ]
+          elif [ "$GITHUB_REF" == "refs/heads/main" ] || [ "$GITHUB_REF" == "refs/heads/master" ]
           then
             # This is the main branch and it's not a prerelease, so the dist-tag should be `latest`.
             DIST_TAG=latest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes: #921  so we add the latest tag on npm.

Currently we [publish the package](https://www.npmjs.com/package/@supabase/auth-js?activeTab=versions) but the tag doesn't seem to be appended correctly