### PR TITLE
fix: don't refresh session if autoRefreshToken setting is set to false

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -241,7 +241,7 @@ export interface Session {
   /**
    * A one-time used refresh token that never expires.
    */
-  refresh_token: string
+  refresh_token?: string
   /**
    * The number of seconds until the token expires (since it was issued). Returned when a login is confirmed.
    */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Supabase client will ignore `autoRefreshToken` setting when setting a session with an expired access token
Breaking Change - `Session` type now has `refresh_token` as optional

## What is the current behavior?

When a Supabase client is initialized with `{ auth: { autoRefreshToken: false } }`

```
const client = createClient(options.supabaseUrl, options.supabaseKey, {
    auth: { autoRefreshToken: false }
});
```
but a session is set with `client.setSession()` and the access token is expired the client will disregard the `autoRefreshToken` setting and attempt to refresh the session.

## What is the new behavior?

The client will not attempt to refresh an expired session when it is set with `client.setSession()` and  `autoRefreshToken` is set to `false`.
