### PR TITLE
remove redundant `getSession` type

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -997,7 +997,7 @@ export default class GoTrueClient {
       result:
         | {
             data: {
-              session: Session
+              session: Session | null
             }
             error: null
           }
@@ -1006,12 +1006,6 @@ export default class GoTrueClient {
               session: null
             }
             error: AuthError
-          }
-        | {
-            data: {
-              session: null
-            }
-            error: null
           }
     ) => Promise<R>
   ): Promise<R> {
@@ -1035,7 +1029,7 @@ export default class GoTrueClient {
   private async __loadSession(): Promise<
     | {
         data: {
-          session: Session
+          session: Session | null
         }
         error: null
       }
@@ -1044,12 +1038,6 @@ export default class GoTrueClient {
           session: null
         }
         error: AuthError
-      }
-    | {
-        data: {
-          session: null
-        }
-        error: null
       }
   > {
     this._debug('#__loadSession()', 'begin')


### PR DESCRIPTION
## What kind of change does this PR introduce?

A fix for the `getSession` return type.

## What is the current behavior?

It was difficult to use the following utility function:
```ts
async function withThrowOnError<T>(
  promise: Promise<{ data: T; error: null } | { data: unknown; error: Error }>,
): Promise<T> {
  const { data, error } = await promise;
  if (error) throw error;
  return data;
}

withThrowOnError(supabase.auth.getSession()); // Type `null` is not assignable to type `Session`.
```

## What is the new behavior?

It conveniently fixes the type error without breaking anything.