### PR TITLE
fix: update types 

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,7 @@ export type Provider =
   | 'linkedin_oidc'
   | 'notion'
   | 'slack'
+  | 'slack_oidc'
   | 'spotify'
   | 'twitch'
   | 'twitter'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -444,7 +444,7 @@ export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
    *
    * Allows you to specify a password hash for the user. This is useful for migrating a user's password hash from another service.
    *
-   * Supports bcryot and argon2 password hashes.
+   * Supports bcrypt and argon2 password hashes.
    */
   password_hash?: string
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -438,6 +438,22 @@ export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
    * Setting this role to `service_role` is not recommended as it grants the user admin privileges.
    */
   role?: string
+
+  /**
+   * The `password_hash` for the user's password.
+   *
+   * Allows you to specify a password hash for the user. This is useful for migrating a user's password hash from another service.
+   *
+   * Supports bcryot and argon2 password hashes.
+   */
+  password_hash?: string
+
+  /**
+   * The `id` for the user.
+   *
+   * Allows you to overwrite the default `id` set for the user.
+   */
+  id?: string
 }
 
 export interface Subscription {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the `slack_oidc` provider, which supports the slack v2 API
* Adds 2 new fields to the admin create user method - `password_hash` and `id`, which allows one to specify a password hash or a custom id when creating a user through the admin method 


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
