### PR TITLE
feat: add bindings for Multi-Factor Authentication (Phone)

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2341,25 +2341,38 @@ export default class GoTrueClient {
           return { data: null, error: sessionError }
         }
 
-        const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
-          body: {
-            friendly_name: params.friendlyName,
-            factor_type: params.factorType,
-            issuer: params.issuer,
-          },
-          headers: this.headers,
-          jwt: sessionData?.session?.access_token,
-        })
-
-        if (error) {
-          return { data: null, error }
+        if (params.factorType === 'sms') {
+          const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
+            body: {
+              friendly_name: params.friendlyName,
+              factor_type: params.factorType,
+              phone_number: params.phoneNumber,
+            },
+            headers: this.headers,
+            jwt: sessionData?.session?.access_token,
+          })
+          if (error) {
+            return { data: null, error }
+          }
+          return { data, error: null }
+        } else {
+          const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
+            body: {
+              friendly_name: params.friendlyName,
+              factor_type: params.factorType,
+              issuer: params.issuer,
+            },
+            headers: this.headers,
+            jwt: sessionData?.session?.access_token,
+          })
+          if (error) {
+            return { data: null, error }
+          }
+          if (data?.totp?.qr_code) {
+            data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
+          }
+          return { data, error: null }
         }
-
-        if (data?.totp?.qr_code) {
-          data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
-        }
-
-        return { data, error: null }
       })
     } catch (error) {
       if (isAuthError(error)) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2442,6 +2442,7 @@ export default class GoTrueClient {
             'POST',
             `${this.url}/factors/${params.factorId}/challenge`,
             {
+              body: { channel: params.channel },
               headers: this.headers,
               jwt: sessionData?.session?.access_token,
             }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2341,7 +2341,7 @@ export default class GoTrueClient {
           return { data: null, error: sessionError }
         }
 
-        if (params.factorType === 'sms') {
+        if (params.factorType === 'phone') {
           const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
             body: {
               friendly_name: params.friendlyName,
@@ -2497,11 +2497,15 @@ export default class GoTrueClient {
     const totp = factors.filter(
       (factor) => factor.factor_type === 'totp' && factor.status === 'verified'
     )
+    const phone = factors.filter(
+      (factor) => factor.factor_type === 'phone' && factor.status === 'verified'
+    )
 
     return {
       data: {
         all: factors,
         totp,
+        phone,
       },
       error: null,
     }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2357,6 +2357,11 @@ export default class GoTrueClient {
           return { data: null, error }
         }
 
+        // TODO: Remove once: https://github.com/supabase/auth/pull/1717 is deployed
+        if (params.factorType === 'phone') {
+          delete data.totp
+        }
+
         if (params.factorType === 'totp' && data?.totp?.qr_code) {
           data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
         }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2346,7 +2346,7 @@ export default class GoTrueClient {
             body: {
               friendly_name: params.friendlyName,
               factor_type: params.factorType,
-              phone_number: params.phoneNumber,
+              phone: params.phone,
             },
             headers: this.headers,
             jwt: sessionData?.session?.access_token,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2341,38 +2341,27 @@ export default class GoTrueClient {
           return { data: null, error: sessionError }
         }
 
-        if (params.factorType === 'phone') {
-          const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
-            body: {
-              friendly_name: params.friendlyName,
-              factor_type: params.factorType,
-              phone: params.phone,
-            },
-            headers: this.headers,
-            jwt: sessionData?.session?.access_token,
-          })
-          if (error) {
-            return { data: null, error }
-          }
-          return { data, error: null }
-        } else {
-          const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
-            body: {
-              friendly_name: params.friendlyName,
-              factor_type: params.factorType,
-              issuer: params.issuer,
-            },
-            headers: this.headers,
-            jwt: sessionData?.session?.access_token,
-          })
-          if (error) {
-            return { data: null, error }
-          }
-          if (data?.totp?.qr_code) {
-            data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
-          }
-          return { data, error: null }
+        const body = {
+          friendly_name: params.friendlyName,
+          factor_type: params.factorType,
+          ...(params.factorType === 'phone' ? { phone: params.phone } : { issuer: params.issuer }),
         }
+
+        const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
+          body,
+          headers: this.headers,
+          jwt: sessionData?.session?.access_token,
+        })
+
+        if (error) {
+          return { data: null, error }
+        }
+
+        if (params.factorType === 'totp' && data?.totp?.qr_code) {
+          data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
+        }
+
+        return { data, error: null }
       })
     } catch (error) {
       if (isAuthError(error)) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -302,10 +302,9 @@ export interface Factor {
   friendly_name?: string
 
   /**
-   * Type of factor. Only `totp` supported with this version but may change in
-   * future versions.
+   * Type of factor. `totp` and `phone` supported with this version
    */
-  factor_type: 'totp' | string
+  factor_type: 'totp' | 'phone' | string
 
   /** Factor's status. */
   status: 'verified' | 'unverified'
@@ -471,9 +470,6 @@ export interface Subscription {
   unsubscribe: () => void
 }
 
-export interface UpdatableFactorAttributes {
-  friendlyName: string
-}
 
 export type SignInAnonymouslyCredentials = {
   options?: {
@@ -826,8 +822,6 @@ export type MFAEnrollParams =
 export type MFAUnenrollParams = {
   /** ID of the factor being unenrolled. */
   factorId: string
-  /** Phone number of the SMS Factor being enrolled */
-  phoneNumber: string
 }
 
 export type MFAVerifyParams = {
@@ -886,7 +880,7 @@ export type AuthMFAEnrollResponse =
         /** ID of the factor that was just enrolled (in an unverified state). */
         id: string
 
-        /** Type of MFA factor. Only `totp` supported for now. */
+        /** Type of MFA factor.*/
         type: 'totp'
 
         /** TOTP enrollment information. */
@@ -915,7 +909,7 @@ export type AuthMFAEnrollResponse =
         /** ID of the factor that was just enrolled (in an unverified state). */
         id: string
 
-        /** Type of MFA factor. Only `totp` supported for now. */
+        /** Type of MFA factor. */
         type: 'phone'
 
         /** Friendly name of the factor, useful for distinguishing between factors **/

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -921,7 +921,7 @@ export type AuthMFAEnrollResponse =
         /** Friendly name of the factor, useful for distinguishing between factors **/
         friendly_name?: string
 
-        /** Phone number of the MFA factor. Used to send SMS-es  */
+        /** Phone number of the MFA factor. Used to send messages  */
         phone_number: string
       }
       error: null

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -844,6 +844,8 @@ export type MFAVerifyParams = {
 export type MFAChallengeParams = {
   /** ID of the factor to be challenged. Returned in enroll(). */
   factorId: string
+  /** Messaging channel to use (e.g. whatsapp or sms). Only relevant for phone factors */
+  channel?: 'sms' | 'whatsapp'
 }
 
 export type MFAChallengeAndVerifyParams = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -814,7 +814,7 @@ export type MFAEnrollParams =
       factorType: 'phone'
       /** Human readable name assigned to the factor. */
       friendlyName?: string
-      /** Phone number associated with a factor */
+      /** Phone number associated with a factor. Number should conform to E.164 format */
       phone: string
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -816,7 +816,7 @@ export type MFAEnrollParams =
     }
   | {
       /** The type of factor being enrolled. */
-      factorType: 'sms'
+      factorType: 'phone'
       /** Human readable name assigned to the factor. */
       friendlyName?: string
       /** Phone number associated with a factor */
@@ -916,7 +916,7 @@ export type AuthMFAEnrollResponse =
         id: string
 
         /** Type of MFA factor. Only `totp` supported for now. */
-        type: 'sms'
+        type: 'phone'
 
         /** Friendly name of the factor, useful for distinguishing between factors **/
         friendly_name?: string
@@ -962,6 +962,8 @@ export type AuthMFAListFactorsResponse =
 
         /** Only verified TOTP factors. (A subset of `all`.) */
         totp: Factor[]
+        /** Only verified Phone factors. (A subset of `all`.) */
+        phone: Factor[]
       }
       error: null
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -805,18 +805,29 @@ export type GenerateLinkType =
   | 'email_change_current'
   | 'email_change_new'
 
-export type MFAEnrollParams = {
-  /** The type of factor being enrolled. */
-  factorType: 'totp'
-  /** Domain which the user is enrolled with. */
-  issuer?: string
-  /** Human readable name assigned to the factor. */
-  friendlyName?: string
-}
+export type MFAEnrollParams =
+  | {
+      /** The type of factor being enrolled. */
+      factorType: 'totp'
+      /** Domain which the user is enrolled with. */
+      issuer?: string
+      /** Human readable name assigned to the factor. */
+      friendlyName?: string
+    }
+  | {
+      /** The type of factor being enrolled. */
+      factorType: 'sms'
+      /** Human readable name assigned to the factor. */
+      friendlyName?: string
+      /** Phone number associated with a factor */
+      phoneNumber: string
+    }
 
 export type MFAUnenrollParams = {
   /** ID of the factor being unenrolled. */
   factorId: string
+  /** Phone number of the SMS Factor being enrolled */
+  phoneNumber: string
 }
 
 export type MFAVerifyParams = {
@@ -894,6 +905,22 @@ export type AuthMFAEnrollResponse =
         }
         /** Friendly name of the factor, useful for distinguishing between factors **/
         friendly_name?: string
+      }
+      error: null
+    }
+  | {
+      data: {
+        /** ID of the factor that was just enrolled (in an unverified state). */
+        id: string
+
+        /** Type of MFA factor. Only `totp` supported for now. */
+        type: 'sms'
+
+        /** Friendly name of the factor, useful for distinguishing between factors **/
+        friendly_name?: string
+
+        /** Phone number of the MFA factor. Used to send SMS-es  */
+        phone_number: string
       }
       error: null
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -940,6 +940,9 @@ export type AuthMFAChallengeResponse =
         /** ID of the newly created challenge. */
         id: string
 
+        /** Factor Type which generated the challenge */
+        type: 'totp' | 'phone'
+
         /** Timestamp in UNIX seconds when this challenge will no longer be usable. */
         expires_at: number
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -470,7 +470,6 @@ export interface Subscription {
   unsubscribe: () => void
 }
 
-
 export type SignInAnonymouslyCredentials = {
   options?: {
     /**
@@ -816,7 +815,7 @@ export type MFAEnrollParams =
       /** Human readable name assigned to the factor. */
       friendlyName?: string
       /** Phone number associated with a factor */
-      phoneNumber: string
+      phone: string
     }
 
 export type MFAUnenrollParams = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -914,8 +914,8 @@ export type AuthMFAEnrollResponse =
         /** Friendly name of the factor, useful for distinguishing between factors **/
         friendly_name?: string
 
-        /** Phone number of the MFA factor. Used to send messages  */
-        phone_number: string
+        /** Phone number of the MFA factor in E.164 format. Used to send messages  */
+       phone: string
       }
       error: null
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the bindings for MFA (Phone) Client library. In particular, add
- Enroll - now allows for enrollment of Phone Factors
- Challenge for Phone - now takes in a channel
- List Factors - now supports access of Phone factors


### TODOS:
- [x] Remove empty `totp` from response field  on enroll response

### Not addressed yet

- `challengeAndVerify` will currently return an error on the `verify` step when used with a phone factor. We could introduce an alternate behaviour (e.g. terminating at the `challenge` step gracefully) since we have the `type` of the challenge-associated-factor in the response. This is not addressed in this PR