### PR TITLE
feat: add get user by email

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { AuthError } from './errors'
+import { AuthError, CustomAuthError } from './errors'
 import { Fetch } from './fetch'
 
 /** One of the providers supported by GoTrue. */
@@ -223,6 +223,12 @@ export type UserResponse =
         user: null
       }
       error: AuthError
+    }
+  | {
+      data: {
+        user: null
+      }
+      error: CustomAuthError
     }
 
 export interface Session {

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -136,6 +136,22 @@ describe('GoTrueAdminApi', () => {
       expect(foundUser).not.toBeUndefined()
       expect(foundUser.user?.email).toEqual(email)
     })
+
+    test('getUserByEmail() should a registered user given its email', async () => {
+      const { email } = mockUserCredentials()
+      const { error: createError, data: createdUser } = await createNewUserWithEmail({ email })
+
+      expect(createError).toBeNull()
+      expect(createdUser.user).not.toBeUndefined()
+
+      const { error: foundError, data: foundUser } = await serviceRoleApiClient.getUserByEmail(
+        email
+      )
+
+      expect(foundError).toBeNull()
+      expect(foundUser).not.toBeUndefined()
+      expect(foundUser.user?.email).toEqual(email)
+    })
   })
 
   describe('User updates', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a `supabase.auth.admin.getUserByEmail` function to the auth-js client. 


## What is the current behavior?
We only have `supabase.auth.admin.getUserById` but not `supabase.auth.admin.getUserByEmail`

https://github.com/supabase/auth/issues/880

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
