### PR TITLE
fix: Correct typo in GoTrueClient warning message

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1465,7 +1465,7 @@ export default class GoTrueClient {
         )
       } else if (timeNow - issuedAt < 0) {
         console.warn(
-          '@supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clok for skew',
+          '@supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clock for skew',
           issuedAt,
           expiresAt,
           timeNow


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR corrects the spelling of `clock` in a warning message in `GoTrueClient.ts`.

## What is the current behavior?

```
@supabase_supabase-js.js?v=12ace510:5329 @supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clok for skew 
```

## What is the new behavior?

```
@supabase_supabase-js.js?v=12ace510:5329 @supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clock for skew 
```

## Additional context

![image](https://github.com/user-attachments/assets/e25b10cc-93e1-48e0-9881-a31ede7b07ef)

