### PR TITLE
ci: add docker-compose to CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2'
+
       - name: Build
         run: |
           npm ci


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the CI job that currently fails by installing docker-compose as part of the workflow.

See: https://github.com/marketplace/actions/setup-docker-compose

## What is the current behavior?

```
Run npm t

> @supabase/auth-js@0.0.0 test
> run-s test:clean test:infra test:suite test:clean


> @supabase/auth-js@0.0.0 test:clean
> cd infra && docker-compose down

sh: 1: docker-compose: not found
ERROR: "test:clean" exited with 12[7](https://github.com/supabase/auth-js/actions/runs/10230643343/job/28322081591?pr=938#step:5:8).
```

## What is the new behavior?

![image](https://github.com/user-attachments/assets/3161f82c-94f7-4606-8f3f-baf062283654)


## Additional context

![image](https://github.com/user-attachments/assets/28941934-0222-4727-9333-442e22cdf2ca)

