### PR TITLE
fix: move docker compose to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint ./src/**/* test/**/*.test.ts",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 30",
-    "test:clean": "cd infra && docker-compose down",
+    "test:infra": "cd infra && docker compose down && docker compose pull && docker compose up -d && sleep 30",
+    "test:clean": "cd infra && docker compose down",
     "docs": "typedoc src/index.ts --out docs/v2 --excludePrivate --excludeProtected",
     "docs:json": "typedoc --json docs/v2/spec.json --excludeExternals --excludePrivate --excludeProtected src/index.ts"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

See announcements: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

`docker-compose` (V1) is no longer in ubuntu-latest 22.04