### PR TITLE
fix: add MFA for WebAuthn bindings

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -36,6 +36,10 @@ import {
   supportsLocalStorage,
   parseParametersFromURL,
   getCodeChallengeAndMethod,
+  base64URLStringToBuffer,
+  bufferToBase64URLString,
+  startRegistration,
+  startAuthentication,
 } from './lib/helpers'
 import { localStorageAdapter, memoryLocalStorageAdapter } from './lib/local-storage'
 import { polyfillGlobalThis } from './lib/polyfills'
@@ -71,12 +75,14 @@ import type {
   VerifyOtpParams,
   GoTrueMFAApi,
   MFAEnrollParams,
-  AuthMFAEnrollResponse,
+  MFAVerifyParams,
   MFAChallengeParams,
   AuthMFAChallengeResponse,
   MFAUnenrollParams,
   AuthMFAUnenrollResponse,
-  MFAVerifyParams,
+  MFAVerifyTOTPParams,
+  MFAVerifyPhoneParams,
+  MFAVerifyWebAuthnParams,
   AuthMFAVerifyResponse,
   AuthMFAListFactorsResponse,
   AMREntry,
@@ -89,12 +95,19 @@ import type {
   LockFunc,
   UserIdentity,
   SignInAnonymouslyCredentials,
+  AuthenticatorTransportFuture,
+  PublicKeyCredentialCreationOptionsJSON,
+  RegistrationResponseJSON,
+  MFAVerifySingleStepWebAuthnParams,
+  AuthMFAEnrollResponse,
 } from './lib/types'
 import {
   MFAEnrollTOTPParams,
   MFAEnrollPhoneParams,
+  MFAEnrollWebAuthnParams,
   AuthMFAEnrollTOTPResponse,
   AuthMFAEnrollPhoneResponse,
+  AuthMFAEnrollWebAuthnResponse,
 } from './lib/internal-types'
 
 polyfillGlobalThis() // Make "globalThis" available
@@ -2386,6 +2399,7 @@ export default class GoTrueClient {
    */
   private async _enroll(params: MFAEnrollTOTPParams): Promise<AuthMFAEnrollTOTPResponse>
   private async _enroll(params: MFAEnrollPhoneParams): Promise<AuthMFAEnrollPhoneResponse>
+  private async _enroll(params: MFAEnrollWebAuthnParams): Promise<AuthMFAEnrollWebAuthnResponse>
   private async _enroll(params: MFAEnrollParams): Promise<AuthMFAEnrollResponse> {
     try {
       return await this._useSession(async (result) => {
@@ -2409,9 +2423,35 @@ export default class GoTrueClient {
         if (error) {
           return { data: null, error }
         }
-
         if (params.factorType === 'totp' && data?.totp?.qr_code) {
           data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`
+        }
+        if (params.factorType === 'webauthn' && data.type === 'webauthn') {
+          if (params.useMultiStep) {
+            return { data, error: null }
+          }
+          const factorId = data.id
+          const webAuthn = this._getWebAuthnRpDetails()
+          const { data: challengeData, error: challengeError } = await this._challenge({
+            factorId,
+            webAuthn,
+          })
+          if (challengeError) {
+            return { data: null, error: challengeError }
+          }
+
+          if (!(challengeData.type === 'webauthn' && challengeData?.credential_creation_options)) {
+            return { data: null, error: new Error('Invalid challenge data for WebAuthn') }
+          }
+          let challengeOptions = challengeData?.credential_creation_options.publicKey
+          let credential = await startRegistration(challengeOptions)
+          const verifyWebAuthnParams = { ...webAuthn, creationResponse: credential }
+
+          return await this._verify({
+            factorId,
+            challengeId: challengeData.id,
+            webAuthn: verifyWebAuthnParams,
+          })
         }
 
         return { data, error: null }
@@ -2424,46 +2464,179 @@ export default class GoTrueClient {
     }
   }
 
+  private _getWebAuthnRpDetails() {
+    const rpId = window.location.hostname
+    const rpOrigins = new URL(window.location.href).origin
+    return { rpId, rpOrigins }
+  }
+
   /**
    * {@see GoTrueMFAApi#verify}
    */
+  private async _verify(params: MFAVerifyTOTPParams): Promise<AuthMFAVerifyResponse>
+  private async _verify(params: MFAVerifyPhoneParams): Promise<AuthMFAVerifyResponse>
+  private async _verify(params: MFAVerifyWebAuthnParams): Promise<AuthMFAVerifyResponse>
   private async _verify(params: MFAVerifyParams): Promise<AuthMFAVerifyResponse> {
     return this._acquireLock(-1, async () => {
       try {
-        return await this._useSession(async (result) => {
-          const { data: sessionData, error: sessionError } = result
-          if (sessionError) {
-            return { data: null, error: sessionError }
-          }
-
-          const { data, error } = await _request(
-            this.fetch,
-            'POST',
-            `${this.url}/factors/${params.factorId}/verify`,
-            {
-              body: { code: params.code, challenge_id: params.challengeId },
-              headers: this.headers,
-              jwt: sessionData?.session?.access_token,
-            }
-          )
-          if (error) {
-            return { data: null, error }
-          }
-
-          await this._saveSession({
-            expires_at: Math.round(Date.now() / 1000) + data.expires_in,
-            ...data,
-          })
-          await this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data)
-
-          return { data, error }
-        })
+        if ('code' in params && 'challengeId' in params && 'factorId' in params) {
+          return this._verifyCodeChallenge(params)
+        } else if ('factorType' in params && params.factorType === 'webauthn') {
+          return this._verifyWebAuthnSingleStep(params)
+        } else if ('webAuthn' in params && params.webAuthn) {
+          return this._verifyWebAuthnCreation(params)
+        }
+        return { data: null, error: new AuthError('Invalid MFA parameters') }
       } catch (error) {
         if (isAuthError(error)) {
           return { data: null, error }
         }
         throw error
       }
+    })
+  }
+
+  private async _verifyWebAuthnSingleStep(
+    params: MFAVerifyWebAuthnParams
+  ): Promise<AuthMFAVerifyResponse> {
+    const {
+      data: { user },
+      error: userError,
+    } = await this._getUser()
+    const factors = user?.factors || []
+
+    const webauthn = factors.filter(
+      (factor) => factor.factor_type === 'webauthn' && factor.status === 'verified'
+    )
+
+    const webAuthnFactor = webauthn[0]
+    if (!webAuthnFactor) {
+      return { data: null, error: new AuthError('No WebAuthn factor found') }
+    }
+    return this._useSession(async (sessionResult) => {
+      const { data: sessionData, error: sessionError } = sessionResult
+      if (sessionError) {
+        return { data: null, error: sessionError }
+      }
+      // Single Step enroll
+      const webAuthn = this._getWebAuthnRpDetails()
+
+      const { data: challengeData, error: challengeError } = await this._challenge({
+        factorId: webAuthnFactor.id,
+        webAuthn,
+      })
+      if (
+        !challengeData ||
+        !(challengeData.type === 'webauthn' && challengeData?.credential_request_options)
+      ) {
+        return {
+          data: null,
+          error: new Error('Invalid challenge data for WebAuthn'),
+        }
+      }
+      const challengeOptions = challengeData?.credential_request_options.publicKey
+      const finalCredential = await startAuthentication(challengeOptions)
+      const verifyWebAuthnParams = { ...webAuthn, assertionResponse: finalCredential }
+
+      const { data, error } = await _request(
+        this.fetch,
+        'POST',
+        `${this.url}/factors/${webAuthnFactor.id}/verify`,
+        {
+          body: {
+            challenge_id: challengeData.id,
+            web_authn: {
+              rp_id: verifyWebAuthnParams.rpId,
+              rp_origins: verifyWebAuthnParams.rpOrigins,
+              assertion_response: verifyWebAuthnParams.assertionResponse,
+            },
+          },
+          headers: this.headers,
+          jwt: sessionData?.session?.access_token,
+        }
+      )
+      if (error) {
+        return { data: null, error }
+      }
+
+      await this._saveSession({
+        expires_at: Math.round(Date.now() / 1000) + data.expires_in,
+        ...data,
+      })
+      await this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data)
+      return { data, error }
+    })
+  }
+
+  private async _verifyWebAuthnCreation(
+    params: MFAVerifySingleStepWebAuthnParams
+  ): Promise<AuthMFAVerifyResponse> {
+    return this._useSession(async (sessionResult) => {
+      const { data: sessionData, error: sessionError } = sessionResult
+      if (sessionError) return { data: null, error: sessionError }
+
+      if (!params.webAuthn) {
+        return { data: null, error: new AuthError('Invalid MFA parameters') }
+      }
+
+      const { data, error } = await _request(
+        this.fetch,
+        'POST',
+        `${this.url}/factors/${params.factorId}/verify`,
+        {
+          body: {
+            challenge_id: params.challengeId,
+            web_authn: {
+              rp_id: params.webAuthn.rpId,
+              rp_origins: params.webAuthn.rpOrigins,
+              creation_response: params.webAuthn.creationResponse,
+            },
+          },
+          headers: this.headers,
+          jwt: sessionData?.session?.access_token,
+        }
+      )
+
+      if (error) return { data: null, error }
+
+      await this._saveSession({
+        expires_at: Math.round(Date.now() / 1000) + data.expires_in,
+        ...data,
+      })
+      await this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data)
+      return { data, error }
+    })
+  }
+
+  private async _verifyCodeChallenge(
+    params: MFAVerifyTOTPParams | MFAVerifyPhoneParams
+  ): Promise<AuthMFAVerifyResponse> {
+    return this._useSession(async (sessionResult) => {
+      const { data: sessionData, error: sessionError } = sessionResult
+      if (sessionError) return { data: null, error: sessionError }
+
+      const { data, error } = await _request(
+        this.fetch,
+        'POST',
+        `${this.url}/factors/${params.factorId}/verify`,
+        {
+          body: {
+            code: params.code,
+            challenge_id: params.challengeId,
+          },
+          headers: this.headers,
+          jwt: sessionData?.session?.access_token,
+        }
+      )
+
+      if (error) return { data: null, error }
+
+      await this._saveSession({
+        expires_at: Math.round(Date.now() / 1000) + data.expires_in,
+        ...data,
+      })
+      await this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data)
+      return { data, error }
     })
   }
 
@@ -2479,12 +2652,24 @@ export default class GoTrueClient {
             return { data: null, error: sessionError }
           }
 
+          let body: Record<string, any> = {}
+          if ('webAuthn' in params && params.webAuthn?.rpId) {
+            body = {
+              web_authn: {
+                rp_id: params.webAuthn.rpId,
+                rp_origins: params.webAuthn.rpOrigins,
+              },
+            }
+          } else if ('channel' in params) {
+            body = { channel: params.channel }
+          }
+
           return await _request(
             this.fetch,
             'POST',
             `${this.url}/factors/${params.factorId}/challenge`,
             {
-              body: { channel: params.channel },
+              body,
               headers: this.headers,
               jwt: sessionData?.session?.access_token,
             }
@@ -2502,22 +2687,29 @@ export default class GoTrueClient {
   /**
    * {@see GoTrueMFAApi#challengeAndVerify}
    */
+  private async _challengeAndVerify(params: {
+    factorId: string
+    code: string
+  }): Promise<AuthMFAVerifyResponse>
   private async _challengeAndVerify(
     params: MFAChallengeAndVerifyParams
   ): Promise<AuthMFAVerifyResponse> {
-    // both _challenge and _verify independently acquire the lock, so no need
-    // to acquire it here
-
-    const { data: challengeData, error: challengeError } = await this._challenge({
+    if (!('factorId' in params && 'code' in params)) {
+      return {
+        data: null,
+        error: new AuthError('Invalid parameters', 400, 'invalid_parameters'),
+      }
+    }
+    const { factorId, code } = params
+    const { data: challengeResponse, error: challengeError } = await this._challenge({
       factorId: params.factorId,
     })
     if (challengeError) {
       return { data: null, error: challengeError }
     }
-
     return await this._verify({
       factorId: params.factorId,
-      challengeId: challengeData.id,
+      challengeId: challengeResponse.id,
       code: params.code,
     })
   }
@@ -2543,11 +2735,16 @@ export default class GoTrueClient {
       (factor) => factor.factor_type === 'phone' && factor.status === 'verified'
     )
 
+    const webauthn = factors.filter(
+      (factor) => factor.factor_type === 'webauthn' && factor.status === 'verified'
+    )
+
     return {
       data: {
         all: factors,
         totp,
         phone,
+        webauthn,
       },
       error: null,
     }

--- a/src/lib/base64url.ts
+++ b/src/lib/base64url.ts
@@ -1,0 +1,265 @@
+/**
+ * Avoid modifying this file. It's part of
+ * https://github.com/supabase-community/base64url-js.  Submit all fixes on
+ * that repo!
+ */
+
+/**
+ * An array of characters that encode 6 bits into a Base64-URL alphabet
+ * character.
+ */
+const TO_BASE64URL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'.split('')
+
+/**
+ * An array of characters that can appear in a Base64-URL encoded string but
+ * should be ignored.
+ */
+const IGNORE_BASE64URL = ' \t\n\r='.split('')
+
+/**
+ * An array of 128 numbers that map a Base64-URL character to 6 bits, or if -2
+ * used to skip the character, or if -1 used to error out.
+ */
+const FROM_BASE64URL = (() => {
+  const charMap: number[] = new Array(128)
+
+  for (let i = 0; i < charMap.length; i += 1) {
+    charMap[i] = -1
+  }
+
+  for (let i = 0; i < IGNORE_BASE64URL.length; i += 1) {
+    charMap[IGNORE_BASE64URL[i].charCodeAt(0)] = -2
+  }
+
+  for (let i = 0; i < TO_BASE64URL.length; i += 1) {
+    charMap[TO_BASE64URL[i].charCodeAt(0)] = i
+  }
+
+  return charMap
+})()
+
+/**
+ * Converts a byte to a Base64-URL string.
+ *
+ * @param byte The byte to convert, or null to flush at the end of the byte sequence.
+ * @param state The Base64 conversion state. Pass an initial value of `{ queue: 0, queuedBits: 0 }`.
+ * @param emit A function called with the next Base64 character when ready.
+ */
+export function byteToBase64URL(
+  byte: number | null,
+  state: { queue: number; queuedBits: number },
+  emit: (char: string) => void
+) {
+  if (byte !== null) {
+    state.queue = (state.queue << 8) | byte
+    state.queuedBits += 8
+
+    while (state.queuedBits >= 6) {
+      const pos = (state.queue >> (state.queuedBits - 6)) & 63
+      emit(TO_BASE64URL[pos])
+      state.queuedBits -= 6
+    }
+  } else if (state.queuedBits > 0) {
+    state.queue = state.queue << (6 - state.queuedBits)
+    state.queuedBits = 6
+
+    while (state.queuedBits >= 6) {
+      const pos = (state.queue >> (state.queuedBits - 6)) & 63
+      emit(TO_BASE64URL[pos])
+      state.queuedBits -= 6
+    }
+  }
+}
+
+/**
+ * Converts a String char code (extracted using `string.charCodeAt(position)`) to a sequence of Base64-URL characters.
+ *
+ * @param charCode The char code of the JavaScript string.
+ * @param state The Base64 state. Pass an initial value of `{ queue: 0, queuedBits: 0 }`.
+ * @param emit A function called with the next byte.
+ */
+export function byteFromBase64URL(
+  charCode: number,
+  state: { queue: number; queuedBits: number },
+  emit: (byte: number) => void
+) {
+  const bits = FROM_BASE64URL[charCode]
+
+  if (bits > -1) {
+    // valid Base64-URL character
+    state.queue = (state.queue << 6) | bits
+    state.queuedBits += 6
+
+    while (state.queuedBits >= 8) {
+      emit((state.queue >> (state.queuedBits - 8)) & 0xff)
+      state.queuedBits -= 8
+    }
+  } else if (bits === -2) {
+    // ignore spaces, tabs, newlines, =
+    return
+  } else {
+    throw new Error(`Invalid Base64-URL character "${String.fromCharCode(charCode)}"`)
+  }
+}
+
+/**
+ * Converts a JavaScript string (which may include any valid character) into a
+ * Base64-URL encoded string. The string is first encoded in UTF-8 which is
+ * then encoded as Base64-URL.
+ *
+ * @param str The string to convert.
+ */
+export function stringToBase64URL(str: string) {
+  const base64: string[] = []
+
+  const emitter = (char: string) => {
+    base64.push(char)
+  }
+
+  const state = { queue: 0, queuedBits: 0 }
+
+  stringToUTF8(str, (byte: number) => {
+    byteToBase64URL(byte, state, emitter)
+  })
+
+  byteToBase64URL(null, state, emitter)
+
+  return base64.join('')
+}
+
+/**
+ * Converts a Base64-URL encoded string into a JavaScript string. It is assumed
+ * that the underlying string has been encoded as UTF-8.
+ *
+ * @param str The Base64-URL encoded string.
+ */
+export function stringFromBase64URL(str: string) {
+  const conv: string[] = []
+
+  const utf8Emit = (codepoint: number) => {
+    conv.push(String.fromCodePoint(codepoint))
+  }
+
+  const utf8State = {
+    utf8seq: 0,
+    codepoint: 0,
+  }
+
+  const b64State = { queue: 0, queuedBits: 0 }
+
+  const byteEmit = (byte: number) => {
+    stringFromUTF8(byte, utf8State, utf8Emit)
+  }
+
+  for (let i = 0; i < str.length; i += 1) {
+    byteFromBase64URL(str.charCodeAt(i), b64State, byteEmit)
+  }
+
+  return conv.join('')
+}
+
+/**
+ * Converts a Unicode codepoint to a multi-byte UTF-8 sequence.
+ *
+ * @param codepoint The Unicode codepoint.
+ * @param emit      Function which will be called for each UTF-8 byte that represents the codepoint.
+ */
+export function codepointToUTF8(codepoint: number, emit: (byte: number) => void) {
+  if (codepoint <= 0x7f) {
+    emit(codepoint)
+    return
+  } else if (codepoint <= 0x7ff) {
+    emit(0xc0 | (codepoint >> 6))
+    emit(0x80 | (codepoint & 0x3f))
+    return
+  } else if (codepoint <= 0xffff) {
+    emit(0xe0 | (codepoint >> 12))
+    emit(0x80 | ((codepoint >> 6) & 0x3f))
+    emit(0x80 | (codepoint & 0x3f))
+    return
+  } else if (codepoint <= 0x10ffff) {
+    emit(0xf0 | (codepoint >> 18))
+    emit(0x80 | ((codepoint >> 12) & 0x3f))
+    emit(0x80 | ((codepoint >> 6) & 0x3f))
+    emit(0x80 | (codepoint & 0x3f))
+    return
+  }
+
+  throw new Error(`Unrecognized Unicode codepoint: ${codepoint.toString(16)}`)
+}
+
+/**
+ * Converts a JavaScript string to a sequence of UTF-8 bytes.
+ *
+ * @param str  The string to convert to UTF-8.
+ * @param emit Function which will be called for each UTF-8 byte of the string.
+ */
+export function stringToUTF8(str: string, emit: (byte: number) => void) {
+  for (let i = 0; i < str.length; i += 1) {
+    let codepoint = str.charCodeAt(i)
+
+    if (codepoint > 0xd7ff && codepoint <= 0xdbff) {
+      // most UTF-16 codepoints are Unicode codepoints, except values in this
+      // range where the next UTF-16 codepoint needs to be combined with the
+      // current one to get the Unicode codepoint
+      const highSurrogate = ((codepoint - 0xd800) * 0x400) & 0xffff
+      const lowSurrogate = (str.charCodeAt(i + 1) - 0xdc00) & 0xffff
+      codepoint = (lowSurrogate | highSurrogate) + 0x10000
+      i += 1
+    }
+
+    codepointToUTF8(codepoint, emit)
+  }
+}
+
+/**
+ * Converts a UTF-8 byte to a Unicode codepoint.
+ *
+ * @param byte  The UTF-8 byte next in the sequence.
+ * @param state The shared state between consecutive UTF-8 bytes in the
+ *              sequence, an object with the shape `{ utf8seq: 0, codepoint: 0 }`.
+ * @param emit  Function which will be called for each codepoint.
+ */
+export function stringFromUTF8(
+  byte: number,
+  state: { utf8seq: number; codepoint: number },
+  emit: (codepoint: number) => void
+) {
+  if (state.utf8seq === 0) {
+    if (byte <= 0x7f) {
+      emit(byte)
+      return
+    }
+
+    // count the number of 1 leading bits until you reach 0
+    for (let leadingBit = 1; leadingBit < 6; leadingBit += 1) {
+      if (((byte >> (7 - leadingBit)) & 1) === 0) {
+        state.utf8seq = leadingBit
+        break
+      }
+    }
+
+    if (state.utf8seq === 2) {
+      state.codepoint = byte & 31
+    } else if (state.utf8seq === 3) {
+      state.codepoint = byte & 15
+    } else if (state.utf8seq === 4) {
+      state.codepoint = byte & 7
+    } else {
+      throw new Error('Invalid UTF-8 sequence')
+    }
+
+    state.utf8seq -= 1
+  } else if (state.utf8seq > 0) {
+    if (byte <= 0x7f) {
+      throw new Error('Invalid UTF-8 sequence')
+    }
+
+    state.codepoint = (state.codepoint << 6) | (byte & 63)
+    state.utf8seq -= 1
+
+    if (state.utf8seq === 0) {
+      emit(state.codepoint)
+    }
+  }
+}

--- a/src/lib/internal-types.ts
+++ b/src/lib/internal-types.ts
@@ -16,6 +16,20 @@ export type MFAEnrollPhoneParams = {
   /** Phone number associated with a factor. Number should conform to E.164 format */
   phone: string
 }
+export type MFAEnrollWebAuthnParams = {
+  /** The type of factor being enrolled. */
+  factorType: 'webauthn'
+  /** Domain which the user is enrolled with. */
+  issuer?: string
+  /** Human readable name assigned to the factor. */
+  friendlyName?: string
+
+  /** WebAuthn specific parameters*/
+  webAuthn?: Object
+
+  /** Have the Auth client library handle the browser-authenticator interaction for you */
+  useMultiStep: boolean
+}
 
 export type AuthMFAEnrollTOTPResponse =
   | {
@@ -66,6 +80,25 @@ export type AuthMFAEnrollPhoneResponse =
 
         /** Phone number of the MFA factor in E.164 format. Used to send messages  */
         phone: string
+      }
+      error: null
+    }
+  | {
+      data: null
+      error: AuthError
+    }
+
+export type AuthMFAEnrollWebAuthnResponse =
+  | {
+      data: {
+        /** ID of the factor that was just enrolled (in an unverified state). */
+        id: string
+
+        /** Type of MFA factor. */
+        type: 'phone'
+
+        /** Friendly name of the factor, useful for distinguishing between factors **/
+        friendly_name?: string
       }
       error: null
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

We introduce bindings for MFA (WebAuthn) which consists of primary methods and helper methods. 

### Core Methods

The core methods have single step and multi-step use.  A single step enroll handles the browser interactions for you while the multi-step enroll provides one the freedom to configure options as they wish.

For enrollment single step looks like:

```
await supabase.auth. enroll({factorType: 'webauthn'})
```

While mutli-step enroll contains a webAuthn parameter than can be customized

```
enroll(factorType: 'webauthn, webAuthn{...}`)
```

Verify operates in a similar fashion.

 There are two methods, `challenge` and `challengeAndVerify` which are affected.

### Helper methods

We provide the following helper methods for ease of use:

1. `browserSupportsWebAuthn` - most modern browsers should support the WebAuthn specification.
2. `startRegistration` - this method takes reference from SimpleWebAuthn and wraps `navigator.create`. Use this to customize how a credential is created
3. `startAuthentication` - this methods takes reference from SimpleWebAuthn and wraps `navigator.get`. Use this to customize how a credential is retrieved 
