### PR TITLE
chore: update workflow check-conventional-commits

### DIFF
--- a/.github/workflows/conventional-commits-lint.js
+++ b/.github/workflows/conventional-commits-lint.js
@@ -16,7 +16,7 @@ const ALLOWED_CONVENTIONAL_COMMIT_PREFIXES = [
 ];
 
 const object = process.argv[2];
-const payload = JSON.parse(fs.readFileSync(process.stdin.fd, "utf-8"));
+const payload = JSON.parse(fs.readFileSync(process.argv[3], "utf-8"));
 
 let validate = [];
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,10 +16,15 @@ on:
       - reopened
       - ready_for_review
 
+permissions: 
+  contents: read
+
 jobs:
   check-conventional-commits:
     runs-on: ubuntu-latest
-
+    if: github.actor != 'dependabot[bot]' # skip for dependabot PRs
+    env:
+      EVENT: ${{ toJSON(github.event) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,13 +35,13 @@ jobs:
         run: |
           set -ex
           TMP_FILE=$(mktemp)
-          echo '${{ toJSON(github.event) }}' > "$TMP_FILE"
-          node .github/workflows/conventional-commits-lint.js pr "$TMP_FILE"
+          echo "${EVENT}" > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js pr "${TMP_FILE}"
 
       - if: ${{ github.event_name == 'push' }}
         run: |
           set -ex
 
           TMP_FILE=$(mktemp)
-          echo '${{ toJSON(github.event) }}' > "$TMP_FILE"
-          node .github/workflows/conventional-commits-lint.js push "$TMP_FILE"
+          echo "${EVENT}" > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js push "${TMP_FILE}"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -29,15 +29,14 @@ jobs:
       - if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           set -ex
-
-          node .github/workflows/conventional-commits-lint.js pr <<EOF
-          ${{ toJSON(github.event) }}
-          EOF
+          TMP_FILE=$(mktemp)
+          echo '${{ toJSON(github.event) }}' > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js pr "$TMP_FILE"
 
       - if: ${{ github.event_name == 'push' }}
         run: |
           set -ex
 
-          node .github/workflows/conventional-commits-lint.js push <<EOF
-          ${{ toJSON(github.event) }}
-          EOF
+          TMP_FILE=$(mktemp)
+          echo '${{ toJSON(github.event) }}' > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js push "$TMP_FILE"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?

Some github.event messages can break the workflow. Backticks get interpreted by the shell, this is a security risk and also breaks most Dependabot PRs.

## What is the new behavior?

Updates the workflow to deal with special characters that might be interpreted by the shell

## Additional context

Should fix https://github.com/supabase/auth-js/actions/runs/11035778554/job/30652617566
