### PR TITLE
fix: remove phone mfa deletion, match on error codes

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -313,11 +313,8 @@ export default class GoTrueClient {
         if (error) {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
-          // hacky workaround to keep the existing session if there's an error returned from identity linking
-          // TODO: once error codes are ready, we should match against it instead of the message
           if (
-            error?.message === 'Identity is already linked' ||
-            error?.message === 'Identity is already linked to another user'
+            error?.code === identity_already_exists
           ) {
             return { error }
           }
@@ -2386,11 +2383,6 @@ export default class GoTrueClient {
 
         if (error) {
           return { data: null, error }
-        }
-
-        // TODO: Remove once: https://github.com/supabase/auth/pull/1717 is deployed
-        if (params.factorType === 'phone') {
-          delete data.totp
         }
 
         if (params.factorType === 'totp' && data?.totp?.qr_code) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -314,7 +314,7 @@ export default class GoTrueClient {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
           if (
-            error?.code === identity_already_exists
+            error?.code === 'identity_already_exists'
           ) {
             return { error }
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Addresses a few existing TODOs

- Remove the deletion of  TOTP object for backward compatibility
- Matches on identity linking error codes instead of messages