### PR TITLE
fix: move MFA sub types to internal file

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -88,12 +88,13 @@ import type {
   LockFunc,
   UserIdentity,
   SignInAnonymouslyCredentials,
-  MFAEnrollTOTPParams,
-  AuthMFAEnrollTOTPResponse,
-  AuthMFAEnrollErrorResponse,
-  MFAEnrollPhoneParams,
-  AuthMFAEnrollPhoneResponse,
 } from './lib/types'
+import {
+  MFAEnrollTOTPParams,
+  MFAEnrollPhoneParams,
+  AuthMFAEnrollTOTPResponse,
+  AuthMFAEnrollPhoneResponse,
+} from './lib/internal-types'
 
 polyfillGlobalThis() // Make "globalThis" available
 
@@ -313,9 +314,7 @@ export default class GoTrueClient {
         if (error) {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
-          if (
-            error?.code === 'identity_already_exists'
-          ) {
+          if (error?.code === 'identity_already_exists') {
             return { error }
           }
 
@@ -2355,12 +2354,8 @@ export default class GoTrueClient {
   /**
    * {@see GoTrueMFAApi#enroll}
    */
-  private async _enroll(
-    params: MFAEnrollTOTPParams
-  ): Promise<AuthMFAEnrollTOTPResponse | AuthMFAEnrollErrorResponse>
-  private async _enroll(
-    params: MFAEnrollPhoneParams
-  ): Promise<AuthMFAEnrollPhoneResponse | AuthMFAEnrollErrorResponse>
+  private async _enroll(params: MFAEnrollTOTPParams): Promise<AuthMFAEnrollTOTPResponse>
+  private async _enroll(params: MFAEnrollPhoneParams): Promise<AuthMFAEnrollPhoneResponse>
   private async _enroll(params: MFAEnrollParams): Promise<AuthMFAEnrollResponse> {
     try {
       return await this._useSession(async (result) => {

--- a/src/lib/internal-types.ts
+++ b/src/lib/internal-types.ts
@@ -1,0 +1,75 @@
+import { AuthError } from './errors'
+
+export type MFAEnrollTOTPParams = {
+  /** The type of factor being enrolled. */
+  factorType: 'totp'
+  /** Domain which the user is enrolled with. */
+  issuer?: string
+  /** Human readable name assigned to the factor. */
+  friendlyName?: string
+}
+export type MFAEnrollPhoneParams = {
+  /** The type of factor being enrolled. */
+  factorType: 'phone'
+  /** Human readable name assigned to the factor. */
+  friendlyName?: string
+  /** Phone number associated with a factor. Number should conform to E.164 format */
+  phone: string
+}
+
+export type AuthMFAEnrollTOTPResponse =
+  | {
+      data: {
+        /** ID of the factor that was just enrolled (in an unverified state). */
+        id: string
+
+        /** Type of MFA factor.*/
+        type: 'totp'
+
+        /** TOTP enrollment information. */
+        totp: {
+          /** Contains a QR code encoding the authenticator URI. You can
+           * convert it to a URL by prepending `data:image/svg+xml;utf-8,` to
+           * the value. Avoid logging this value to the console. */
+          qr_code: string
+
+          /** The TOTP secret (also encoded in the QR code). Show this secret
+           * in a password-style field to the user, in case they are unable to
+           * scan the QR code. Avoid logging this value to the console. */
+          secret: string
+
+          /** The authenticator URI encoded within the QR code, should you need
+           * to use it. Avoid loggin this value to the console. */
+          uri: string
+        }
+        /** Friendly name of the factor, useful for distinguishing between factors **/
+        friendly_name?: string
+      }
+      error: null
+    }
+  | {
+      data: null
+      error: AuthError
+    }
+
+export type AuthMFAEnrollPhoneResponse =
+  | {
+      data: {
+        /** ID of the factor that was just enrolled (in an unverified state). */
+        id: string
+
+        /** Type of MFA factor. */
+        type: 'phone'
+
+        /** Friendly name of the factor, useful for distinguishing between factors **/
+        friendly_name?: string
+
+        /** Phone number of the MFA factor in E.164 format. Used to send messages  */
+        phone: string
+      }
+      error: null
+    }
+  | {
+      data: null
+      error: AuthError
+    }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,11 @@
 import { AuthError } from './errors'
 import { Fetch } from './fetch'
+import {
+  MFAEnrollTOTPParams,
+  MFAEnrollPhoneParams,
+  AuthMFAEnrollTOTPResponse,
+  AuthMFAEnrollPhoneResponse,
+} from './internal-types'
 
 /** One of the providers supported by GoTrue. */
 export type Provider =
@@ -800,22 +806,6 @@ export type GenerateLinkType =
   | 'email_change_current'
   | 'email_change_new'
 
-export type MFAEnrollTOTPParams = {
-  /** The type of factor being enrolled. */
-  factorType: 'totp'
-  /** Domain which the user is enrolled with. */
-  issuer?: string
-  /** Human readable name assigned to the factor. */
-  friendlyName?: string
-}
-export type MFAEnrollPhoneParams = {
-  /** The type of factor being enrolled. */
-  factorType: 'phone'
-  /** Human readable name assigned to the factor. */
-  friendlyName?: string
-  /** Phone number associated with a factor. Number should conform to E.164 format */
-  phone: string
-}
 export type MFAEnrollParams = MFAEnrollTOTPParams | MFAEnrollPhoneParams
 
 export type MFAUnenrollParams = {
@@ -873,59 +863,7 @@ export type AuthMFAVerifyResponse =
       error: AuthError
     }
 
-export type AuthMFAEnrollTOTPResponse = {
-  data: {
-    /** ID of the factor that was just enrolled (in an unverified state). */
-    id: string
-
-    /** Type of MFA factor.*/
-    type: 'totp'
-
-    /** TOTP enrollment information. */
-    totp: {
-      /** Contains a QR code encoding the authenticator URI. You can
-       * convert it to a URL by prepending `data:image/svg+xml;utf-8,` to
-       * the value. Avoid logging this value to the console. */
-      qr_code: string
-
-      /** The TOTP secret (also encoded in the QR code). Show this secret
-       * in a password-style field to the user, in case they are unable to
-       * scan the QR code. Avoid logging this value to the console. */
-      secret: string
-
-      /** The authenticator URI encoded within the QR code, should you need
-       * to use it. Avoid loggin this value to the console. */
-      uri: string
-    }
-    /** Friendly name of the factor, useful for distinguishing between factors **/
-    friendly_name?: string
-  }
-  error: null
-}
-export type AuthMFAEnrollPhoneResponse = {
-  data: {
-    /** ID of the factor that was just enrolled (in an unverified state). */
-    id: string
-
-    /** Type of MFA factor. */
-    type: 'phone'
-
-    /** Friendly name of the factor, useful for distinguishing between factors **/
-    friendly_name?: string
-
-    /** Phone number of the MFA factor in E.164 format. Used to send messages  */
-    phone: string
-  }
-  error: null
-}
-export type AuthMFAEnrollErrorResponse = {
-  data: null
-  error: AuthError
-}
-export type AuthMFAEnrollResponse =
-  | AuthMFAEnrollTOTPResponse
-  | AuthMFAEnrollPhoneResponse
-  | AuthMFAEnrollErrorResponse
+export type AuthMFAEnrollResponse = AuthMFAEnrollTOTPResponse | AuthMFAEnrollPhoneResponse
 
 export type AuthMFAUnenrollResponse =
   | {
@@ -1010,12 +948,8 @@ export interface GoTrueMFAApi {
    * Upon verifying a factor, all other sessions are logged out and the current session's authenticator level is promoted to `aal2`.
    *
    */
-  enroll(
-    params: MFAEnrollTOTPParams
-  ): Promise<AuthMFAEnrollTOTPResponse | AuthMFAEnrollErrorResponse>
-  enroll(
-    params: MFAEnrollPhoneParams
-  ): Promise<AuthMFAEnrollPhoneResponse | AuthMFAEnrollErrorResponse>
+  enroll(params: MFAEnrollTOTPParams): Promise<AuthMFAEnrollTOTPResponse>
+  enroll(params: MFAEnrollPhoneParams): Promise<AuthMFAEnrollPhoneResponse>
   enroll(params: MFAEnrollParams): Promise<AuthMFAEnrollResponse>
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow up to #956, hides the MFA sub-types (e.g. MFA Phone, MFA TOTP) needed to fix type errors before we release to public so that we can remove them as and when we like. The sub-types are now stored in an `internal-types` file which, unlike the `types` file is not exposed to public.


The types mentioned here have not been released yet so fine to hide them