### PR TITLE
fix: add loose auto complete to string literals where applicable

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -8,7 +8,7 @@ export class AuthError extends Error {
    * before a response is received will not have one present. In that
    * case {@link #status} will also be undefined.
    */
-  code: ErrorCode | string | undefined
+  code: ErrorCode | (string & {}) | undefined
 
   /** HTTP status code that caused the error. */
   status: number | undefined

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,7 +88,7 @@ export type GoTrueClientOptions = {
   hasCustomAuthorizationHeader?: boolean
 }
 
-export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | string
+export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | (string & {})
 export type WeakPassword = {
   reasons: WeakPasswordReasons[]
   message: string
@@ -265,7 +265,7 @@ export interface Session {
  */
 export interface AMREntry {
   /** Authentication method name. */
-  method: 'password' | 'otp' | 'oauth' | 'mfa/totp' | string
+  method: 'password' | 'otp' | 'oauth' | 'mfa/totp' | (string & {})
 
   /**
    * Timestamp when the method was successfully used. Represents number of
@@ -304,7 +304,7 @@ export interface Factor {
   /**
    * Type of factor. `totp` and `phone` supported with this version
    */
-  factor_type: 'totp' | 'phone' | string
+  factor_type: 'totp' | 'phone' | (string & {})
 
   /** Factor's status. */
   status: 'verified' | 'unverified'
@@ -598,7 +598,7 @@ export type SignInWithOAuthCredentials = {
 
 export type SignInWithIdTokenCredentials = {
   /** Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `kakao`, `keycloak` (deprecated). */
-  provider: 'google' | 'apple' | 'azure' | 'facebook' | 'kakao' | string
+  provider: 'google' | 'apple' | 'azure' | 'facebook' | 'kakao' | (string & {})
   /** OIDC ID token issued by the specified provider. The `iss` claim in the ID token must match the supplied provider. Some ID tokens contain an `at_hash` which require that you provide an `access_token` value to be accepted properly. If the token contains a `nonce` claim you must supply the nonce used to obtain the ID token. */
   token: string
   /** If the ID token contains an `at_hash` claim, then the hash of this value is compared to the value in the ID token. */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add "loose autocomplete" to`WeakPasswordReasons`, `AMREntry.method`, `Factor.factor_type`, `SignInWithIdTokenCredentials.provider` and `AuthError.code `


## What is the current behavior?

The above types define possible string literal values, which is great, but they're unioned with `string`. As a regular `"literal" | string` just ends up as a `string` this foregoes the benefit of defining the literals in the first place. 

## What is the new behavior?

TypeScript still allows any possible string as a valid value (notice no error on the "not in there"), but now the predefined literals show up as hints. This is done by using `"literal" | string & {}`. While this seems hacky, it's something that works and something the TS team test against meaning they won't "fix" it in future releases. 

<img width="632" alt="image" src="https://github.com/user-attachments/assets/a6bd07c1-c460-4b80-87ae-2c855e996157">

Currently these hints aren't shown as the type just ends up as a simple `string`.

## Additional context

I believe this can be quite helpful for people when trying to handle errors etc. I know `string & {}` might look somewhat weird for maintainers, if preferable I can create a `LooseAutocomplete<T>` or something and wrap them in there but this seemed cleaner. 
