### PR TITLE
fix: typo in warning message

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1109,7 +1109,7 @@ export default class GoTrueClient {
               if (!suppressWarning && prop === 'user') {
                 // only show warning when the user object is being accessed from the server
                 console.warn(
-                  'Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and many not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.'
+                  'Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and may not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.'
                 )
                 suppressWarning = true // keeps this proxy instance from logging additional warnings
                 this.suppressGetSessionWarning = true // keeps this client's future proxy instances from warning


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a small typo in the warning message when using user object from the server.