### PR TITLE
zitadel provider added in types.ts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,7 @@ export type Provider =
   | 'twitch'
   | 'twitter'
   | 'workos'
+  | 'zitadel'
   | 'zoom'
   | 'fly'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add Zitadel Provider 

## What is the current behavior?

Currently, auth-js does not support Zitadel as an authentication provider.

## What is the new behavior?

With this PR, Zitadel will be available as a provider for authentication, allowing users to authenticate via Zitadel's OpenID Connect (OIDC) implementation.

```
    const { error, data } = await supabase.auth.signInWithOAuth({
      provider: 'zitadel',
      options: {
        redirectTo: `${origin}/auth/callback`,
        scopes: 'openid'  // This parameter is important
      }
    });
```

## Additional context

Add any other context or screenshots.
