### PR TITLE
fix: `isBrowser()` to include check on `window`

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -14,7 +14,8 @@ export function uuid() {
   })
 }
 
-export const isBrowser = () => typeof document !== 'undefined'
+export const isBrowser = () =>
+  typeof window !== 'undefined' && typeof document !== 'undefined'
 
 const localStorageWriteTests = {
   tested: false,


### PR DESCRIPTION
There are several checks in `GoTrueClient.ts` that check `window?.[prop]` after checking `isBrowser()` which throws an error in node environments that have `document` defined but not `window`.

Fixes:

- https://github.com/supabase/supabase-js/issues/786
