### PR TITLE
fix: don't remove session for identity linking errors

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -12,6 +12,7 @@ import {
   isAuthError,
   isAuthRetryableFetchError,
   isAuthSessionMissingError,
+  isAuthImplicitGrantRedirectError,
 } from './lib/errors'
 import {
   Fetch,
@@ -314,8 +315,15 @@ export default class GoTrueClient {
         if (error) {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
-          if (error?.code === 'identity_already_exists') {
-            return { error }
+          if (isAuthImplicitGrantRedirectError(error)) {
+            const errorCode = error.details?.code
+            if (
+              errorCode === 'identity_already_exists' ||
+              errorCode === 'identity_not_found' ||
+              errorCode === 'single_identity_not_deletable'
+            ) {
+              return { error }
+            }
           }
 
           // failed login attempt via url,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -102,6 +102,12 @@ export class AuthImplicitGrantRedirectError extends CustomAuthError {
   }
 }
 
+export function isAuthImplicitGrantRedirectError(
+  error: any
+): error is AuthImplicitGrantRedirectError {
+  return isAuthError(error) && error.name === 'AuthImplicitGrantRedirectError'
+}
+
 export class AuthPKCEGrantCodeExchangeError extends CustomAuthError {
   details: { error: string; code: string } | null = null
 

--- a/src/lib/locks.ts
+++ b/src/lib/locks.ts
@@ -168,7 +168,7 @@ export async function processLock<R>(
 
   const currentOperation = Promise.race(
     [
-      previousOperation.catch((e: any) => {
+      previousOperation.catch(() => {
         // ignore error of previous operation that we're waiting to finish
         return null
       }),


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Don't remove session for identity linking errors
* Dependent on https://github.com/supabase/auth/pull/1855
