### PR TITLE
fix: return error early for redirects

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1423,13 +1423,23 @@ export default class GoTrueClient {
   > {
     try {
       if (!isBrowser()) throw new AuthImplicitGrantRedirectError('No browser detected.')
+
+      const params = parseParametersFromURL(window.location.href)
+      if (params.error || params.error_description || params.error_code) {
+        throw new AuthImplicitGrantRedirectError(
+          params.error_description || 'Error in URL with unspecified error_description',
+          {
+            error: params.error || 'unspecified_error',
+            code: params.error_code || 'unspecified_code',
+          }
+        )
+      }
+
       if (this.flowType === 'implicit' && !this._isImplicitGrantFlow()) {
         throw new AuthImplicitGrantRedirectError('Not a valid implicit grant flow url.')
       } else if (this.flowType == 'pkce' && !isPKCEFlow) {
         throw new AuthPKCEGrantCodeExchangeError('Not a valid PKCE flow url.')
       }
-
-      const params = parseParametersFromURL(window.location.href)
 
       if (isPKCEFlow) {
         if (!params.code) throw new AuthPKCEGrantCodeExchangeError('No code detected.')
@@ -1442,16 +1452,6 @@ export default class GoTrueClient {
         window.history.replaceState(window.history.state, '', url.toString())
 
         return { data: { session: data.session, redirectType: null }, error: null }
-      }
-
-      if (params.error || params.error_description || params.error_code) {
-        throw new AuthImplicitGrantRedirectError(
-          params.error_description || 'Error in URL with unspecified error_description',
-          {
-            error: params.error || 'unspecified_error',
-            code: params.error_code || 'unspecified_code',
-          }
-        )
       }
 
       const {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1425,7 +1425,11 @@ export default class GoTrueClient {
       if (!isBrowser()) throw new AuthImplicitGrantRedirectError('No browser detected.')
 
       const params = parseParametersFromURL(window.location.href)
+
+      // If there's an error in the URL, it doesn't matter what flow it is, we just return the error.
       if (params.error || params.error_description || params.error_code) {
+        // The error class returned implies that the redirect is from an implicit grant flow
+        // but it could also be from a redirect error from a PKCE flow.
         throw new AuthImplicitGrantRedirectError(
           params.error_description || 'Error in URL with unspecified error_description',
           {
@@ -1435,6 +1439,7 @@ export default class GoTrueClient {
         )
       }
 
+      // Checks for mismatches between the flowType initialised in the client and the URL parameters
       if (this.flowType === 'implicit' && !this._isImplicitGrantFlow()) {
         throw new AuthImplicitGrantRedirectError('Not a valid implicit grant flow url.')
       } else if (this.flowType == 'pkce' && !isPKCEFlow) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* When using the PKCE flow, if there's a redirect error after the callback and a code is not returned, `getSessionFromUrl` ends up returning `Not a valid PKCE flow url.` instead of the actual error 
