### PR TITLE
fix: return redirect errors early 

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -307,11 +307,8 @@ export default class GoTrueClient {
    */
   private async _initialize(): Promise<InitializeResult> {
     try {
-      const isPKCEFlow = isBrowser() ? await this._isPKCEFlow() : false
-      this._debug('#_initialize()', 'begin', 'is PKCE flow', isPKCEFlow)
-
-      if (isPKCEFlow || (this.detectSessionInUrl && this._isImplicitGrantFlow())) {
-        const { data, error } = await this._getSessionFromURL(isPKCEFlow)
+      if (isBrowser() && this.detectSessionInUrl) {
+        const { data, error } = await this._getSessionFromURL()
         if (error) {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
@@ -1414,7 +1411,7 @@ export default class GoTrueClient {
   /**
    * Gets the session data from a URL string
    */
-  private async _getSessionFromURL(isPKCEFlow: boolean): Promise<
+  private async _getSessionFromURL(): Promise<
     | {
         data: { session: Session; redirectType: string | null }
         error: null
@@ -1423,15 +1420,39 @@ export default class GoTrueClient {
   > {
     try {
       if (!isBrowser()) throw new AuthImplicitGrantRedirectError('No browser detected.')
-      if (this.flowType === 'implicit' && !this._isImplicitGrantFlow()) {
-        throw new AuthImplicitGrantRedirectError('Not a valid implicit grant flow url.')
-      } else if (this.flowType == 'pkce' && !isPKCEFlow) {
-        throw new AuthPKCEGrantCodeExchangeError('Not a valid PKCE flow url.')
-      }
 
       const params = parseParametersFromURL(window.location.href)
 
-      if (isPKCEFlow) {
+      // If there's an error in the URL, it doesn't matter what flow it is, we just return the error.
+      if (params.error || params.error_description || params.error_code) {
+        // The error class returned implies that the redirect is from an implicit grant flow
+        // but it could also be from a redirect error from a PKCE flow.
+        throw new AuthImplicitGrantRedirectError(
+          params.error_description || 'Error in URL with unspecified error_description',
+          {
+            error: params.error || 'unspecified_error',
+            code: params.error_code || 'unspecified_code',
+          }
+        )
+      }
+
+      const isRedirectFromImplicitGrantFlow = this._isImplicitGrantFlow(params)
+      const isRedirectFromPKCEFlow = await this._isPKCEFlow(params)
+
+      // Checks for mismatches between the flowType initialised in the client and the URL parameters
+      if (!isRedirectFromImplicitGrantFlow && !isRedirectFromPKCEFlow) {
+        if (this.flowType === 'implicit') {
+          throw new AuthImplicitGrantRedirectError('Not a valid implicit grant flow url.')
+        } else if (this.flowType === 'pkce') {
+          throw new AuthPKCEGrantCodeExchangeError('Not a valid PKCE flow url.')
+        } else {
+          throw new AuthError('Invalid flow type.')
+        }
+      }
+
+      // Since this is a redirect for PKCE, we attempt to retrieve the code from the URL for the code exchange
+      if (isRedirectFromPKCEFlow) {
+        this._debug('#_initialize()', 'begin', 'is PKCE flow', isRedirectFromPKCEFlow)
         if (!params.code) throw new AuthPKCEGrantCodeExchangeError('No code detected.')
         const { data, error } = await this._exchangeCodeForSession(params.code)
         if (error) throw error
@@ -1442,16 +1463,6 @@ export default class GoTrueClient {
         window.history.replaceState(window.history.state, '', url.toString())
 
         return { data: { session: data.session, redirectType: null }, error: null }
-      }
-
-      if (params.error || params.error_description || params.error_code) {
-        throw new AuthImplicitGrantRedirectError(
-          params.error_description || 'Error in URL with unspecified error_description',
-          {
-            error: params.error || 'unspecified_error',
-            code: params.error_code || 'unspecified_code',
-          }
-        )
       }
 
       const {
@@ -1531,24 +1542,20 @@ export default class GoTrueClient {
   /**
    * Checks if the current URL contains parameters given by an implicit oauth grant flow (https://www.rfc-editor.org/rfc/rfc6749.html#section-4.2)
    */
-  private _isImplicitGrantFlow(): boolean {
-    const params = parseParametersFromURL(window.location.href)
-
-    return !!(isBrowser() && (params.access_token || params.error_description))
+  private _isImplicitGrantFlow(params: { [parameter: string]: string }): boolean {
+    return !!((params.access_token || params.error_description) && this.flowType === 'implicit')
   }
 
   /**
    * Checks if the current URL and backing storage contain parameters given by a PKCE flow
    */
-  private async _isPKCEFlow(): Promise<boolean> {
-    const params = parseParametersFromURL(window.location.href)
-
+  private async _isPKCEFlow(params: { [parameter: string]: string }): Promise<boolean> {
     const currentStorageContent = await getItemAsync(
       this.storage,
       `${this.storageKey}-code-verifier`
     )
 
-    return !!(params.code && currentStorageContent)
+    return !!(params.code && currentStorageContent && this.flowType === 'pkce')
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes the bug introduced previously in https://github.com/supabase/auth-js/pull/993/files#diff-3522461172efd6058d6b8da62fc2d30d8b524d2b64894ea2c67218c52f7fdff5R310, where it attempted to always try to find a session in the URL, which led to users being logged out on a page refresh
* This PR also reverts the previous PR #992, which returns the error early if there's a redirect, since some redirect errors (like identity linking) should not result in the existing session being removed.
* Tested the following scenarios:
  * Sign in and refresh the page
  * Sign in and attempt to link an already existing identity
  * Sign in and attempt to link a new identity 