### PR TITLE
ci: publish with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   release_please:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     steps:
@@ -102,16 +103,17 @@ jobs:
 
           echo "Publishing auth-js now..."
 
-          npm publish --tag "$DIST_TAG"
+          npm publish --provenance --tag "$DIST_TAG"
 
           echo "Publishing gotrue-js now..."
 
           for f in package.json package-lock.json
           do
-            sed -i 's|\(["/]\)auth-js|\1gotrue-js|g' "$f"
+            # only replace name not repository, homepage, etc.
+            sed -i 's|\("name":[[:space:]]*"@supabase/\)auth-js|\1gotrue-js|g' "$f"
           done
 
-          npm publish --tag "$DIST_TAG"
+          npm publish --provenance --tag "$DIST_TAG"
 
       - name: Create GitHub release and branches
         if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "types": "dist/module/index.d.ts",
-  "repository": "supabase/auth-js",
+  "repository": "github:supabase/auth-js",
   "scripts": {
     "clean": "rimraf dist docs",
     "coverage": "echo \"run npm test\"",


### PR DESCRIPTION
Will publish `auth-js` and `gotrue-js` with [provenance](https://docs.npmjs.com/generating-provenance-statements).