### PR TITLE
fix: add `providers` type to UserAppMetadata interface

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -321,6 +321,7 @@ export interface Factor {
 
 export interface UserAppMetadata {
   provider?: string
+  providers?: string[]
   [key: string]: any
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor type fix.

## What is the current behavior?

If a user has multiple providers associated with them, then Supabase adds a `providers` string array to their `user.app_metadata`, but this is missing from the `UserAppMetadata` type. I just happened to notice this while trying to work around an issue in a demo app, and there was no `providers` intellisense in my IDE.

![image](https://github.com/user-attachments/assets/744d51bf-e4a5-4f59-96ef-55222d984995)

## What is the new behavior?

A `providers?: string[]` type is added to the interface.

## Additional context

An example of multiple providers being associated to a user is if the user signs up with email/password, but then is allowed to add a phone number as well.
