### PR TITLE
Fixes misspelling in types comment

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -256,7 +256,7 @@ export interface Session {
 }
 
 /**
- * An authentication methord reference (AMR) entry.
+ * An authentication method reference (AMR) entry.
  *
  * An entry designates what method was used by the user to verify their
  * identity and at what time.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore.

## What is the current behavior?

Just a misspelled comment.

## What is the new behavior?

Fixed comment with correct spelling.

## Additional context

Pretty simple!
