### PR TITLE
ci: add dogfooding check so that RC version is up on supabase/supabase first

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -1,0 +1,50 @@
+name: Dogfooding Check
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - '*'
+
+jobs:
+  check_dogfooding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release-please--branches--master'
+        with:
+          ref: master # used to identify the latest RC version via git describe --tags --match rc*
+          fetch-depth: 0
+
+      - if: github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release-please--branches--master'
+        run: |
+          set -ex
+
+          # finds the latest RC version on master
+          RELEASE_VERSION=@supabase/auth-js@$(node -e "const a = '$(git describe --tags --match rc*)'.replace(/^rc/, '').split('-'); console.log(a[0] + '-' + a[1]);")
+
+          # use some clever Ruby magic to extract the snapshots['@supabase/auth-js@...'] version from the pnpm-lock.yaml file
+          STUDIO_VERSION=$(curl 'https://raw.githubusercontent.com/supabase/supabase/refs/heads/master/pnpm-lock.yaml' | ruby -e 'require("yaml"); l = YAML.load(STDIN); puts(l["snapshots"].find { |k, v| k.start_with? "@supabase/auth-js" }.first)')
+
+          echo "Expecting RC version $RELEASE_VERSION to be used in Supabase Studio."
+
+          if [ "$STUDIO_VERSION" != "$RELEASE_VERSION" ]
+          then
+            echo "Version in Supabase Studio is not the latest release candidate. Please release this RC first to proof the release before merging this PR."
+            exit 1
+          fi
+
+          echo "Release away!"
+          exit 0
+
+      - if: github.event.pull_request.base.ref != 'master' || github.event.pull_request.head.ref != 'release-please--branches--master'
+        run: |
+          set -ex
+
+          echo "This PR is not subject to dogfooding checks."
+          exit 0
+


### PR DESCRIPTION
Introduces a dogfooding PR check ensuring that the RC version is live on [Supabase Studio](https://github.com/supabase/supabase) before an official version is cut.