### PR TITLE
feat: consider session expired with margin on getSession() without auto refresh

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,21 @@
 import { version } from './version'
+
+/** Current session will be checked for refresh at this interval. */
+export const AUTO_REFRESH_TICK_DURATION_MS = 30 * 1000
+
+/**
+ * A token refresh will be attempted this many ticks before the current session expires. */
+export const AUTO_REFRESH_TICK_THRESHOLD = 3
+
+/*
+ * Earliest time before an access token expires that the session should be refreshed.
+ */
+export const EXPIRY_MARGIN_MS = AUTO_REFRESH_TICK_THRESHOLD * AUTO_REFRESH_TICK_DURATION_MS
+
 export const GOTRUE_URL = 'http://localhost:9999'
 export const STORAGE_KEY = 'supabase.auth.token'
 export const AUDIENCE = ''
 export const DEFAULT_HEADERS = { 'X-Client-Info': `gotrue-js/${version}` }
-export const EXPIRY_MARGIN = 10 // in seconds
 export const NETWORK_FAILURE = {
   MAX_RETRIES: 10,
   RETRY_INTERVAL: 2, // in deciseconds


### PR DESCRIPTION
When `autoRefreshToken` is off (or when a tab is in the background) but `getSession()` is called -- such as in an active Realtime channel, `getSession()` might return a JWT which will expire while the message is travelling over the internet. There is one confirmed case of this happening.

This PR adjusts this using the established `EXPIRY_MARGIN_MS` constant (which only applies on initial initialization of the client). The constant's value is brought in line with the `autoRefreshToken` ticks which run every 30 seconds and refreshing is attempted 3 ticks prior to the session expiring.

This means that JWTs with an expiry value **less than 90s** will always refresh the session; which is acceptable.