### PR TITLE
feat: opt-in update for cross-device/browser otp, 0Auth, and magic link sign in

### DIFF
--- a/infra/db/00-schema.sql
+++ b/infra/db/00-schema.sql
@@ -84,3 +84,22 @@ GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
 ALTER USER postgres SET search_path = "auth";
 
+-- auth.pkce_sessions definition
+CREATE TABLE auth.pkce_sessions (
+    id uuid NOT NULL,
+    session_id varchar(255) NOT NULL,
+    code_verifier varchar(255) NOT NULL,
+    instance_id uuid NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL,
+    CONSTRAINT pkce_sessions_pkey PRIMARY KEY (id),
+    CONSTRAINT pkce_sessions_session_id_key UNIQUE (session_id)
+);
+
+CREATE INDEX pkce_sessions_instance_id_idx ON auth.pkce_sessions USING btree (instance_id);
+CREATE INDEX pkce_sessions_session_id_idx ON auth.pkce_sessions USING btree (session_id);
+CREATE INDEX pkce_sessions_expires_at_idx ON auth.pkce_sessions USING btree (expires_at);
+
+-- Add permissions for the new table
+GRANT ALL PRIVILEGES ON TABLE auth.pkce_sessions TO postgres;
+

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       GOTRUE_SMS_TWILIO_MESSAGE_SERVICE_SID: '${GOTRUE_SMS_TWILIO_MESSAGE_SERVICE_SID}'
       GOTRUE_SMS_AUTOCONFIRM: 'false'
       GOTRUE_COOKIE_KEY: 'sb'
+      GOTRUE_PKCE_CROSS_DEVICE_ENABLED: 'true'
+      GOTRUE_PKCE_SESSION_EXPIRY: '300'
     depends_on:
       - db
     restart: on-failure

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -19,6 +19,7 @@ import {
   AuthMFAAdminListFactorsParams,
   AuthMFAAdminListFactorsResponse,
   PageParams,
+  PKCESession,
 } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
@@ -327,6 +328,55 @@ export default class GoTrueAdminApi {
         return { data: null, error }
       }
 
+      throw error
+    }
+  }
+
+  /**
+   * Lists all active PKCE sessions.
+   * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   */
+  async listPKCESessions(): Promise<
+    { data: { sessions: PKCESession[] }; error: null } | { data: null; error: AuthError }
+  > {
+    try {
+      const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/pkce-sessions`, {
+        headers: this.headers,
+      })
+
+      if (error) throw error
+      return { data, error: null }
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Deletes a PKCE session.
+   * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   */
+  async deletePKCESession(
+    sessionId: string
+  ): Promise<{ data: { success: boolean }; error: null } | { data: null; error: AuthError }> {
+    try {
+      const { data, error } = await _request(
+        this.fetch,
+        'DELETE',
+        `${this.url}/admin/pkce-sessions/${sessionId}`,
+        {
+          headers: this.headers,
+        }
+      )
+
+      if (error) throw error
+      return { data, error: null }
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
       throw error
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1332,3 +1332,46 @@ export interface CrossDeviceOtpResponse {
   messageId?: string | null
   error: AuthError | null
 }
+
+/**
+ * Parameters for initiating cross-device magic link sign in
+ */
+export interface SignInWithMagicLinkCrossDeviceCredentials {
+  /** The user's email address */
+  email: string
+  options?: {
+    /** If set to false, this method will not create a new user. Defaults to true. */
+    shouldCreateUser?: boolean
+    /**
+     * A custom data object to store the user's metadata.
+     */
+    data?: object
+    /** Verification token received when the user completes the captcha on the site. */
+    captchaToken?: string
+    /** The URL to redirect to after successful sign in */
+    redirectTo?: string
+  }
+}
+
+/**
+ * Parameters for completing cross-device magic link sign in
+ */
+export interface CompleteMagicLinkCrossDeviceParams {
+  /** The unique session ID from the cross-device flow */
+  sessionId: string
+  /** The token from the magic link */
+  token: string
+}
+
+/**
+ * Response from initiating a cross-device magic link sign in
+ */
+export interface CrossDeviceMagicLinkResponse {
+  /** Unique session ID for the cross-device flow */
+  sessionId: string
+  /** Email where the magic link was sent */
+  destination: string
+  /** True if the message was successfully sent */
+  messageId?: string | null
+  error: AuthError | null
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,17 @@ export type GoTrueClientOptions = {
    * @experimental
    */
   hasCustomAuthorizationHeader?: boolean
+  /**
+   * Enable cross-browser/device authentication flow
+   * @default false
+   */
+  enableCrossDeviceFlow?: boolean
+
+  /**
+   * Duration in seconds for cross-device PKCE sessions
+   * @default 300 (5 minutes)
+   */
+  crossDeviceSessionDuration?: number
 }
 
 export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | (string & {})
@@ -1227,4 +1238,97 @@ export interface JWK {
   alg?: string
   kid?: string
   [key: string]: any
+}
+
+/**
+ * Parameters for initiating cross-device OAuth sign in
+ */
+export interface SignInWithCrossDeviceOAuthCredentials {
+  /** The Provider to use for the authentication. */
+  provider: Provider
+  /** A URL to send the user to after they are confirmed. */
+  redirectTo?: string
+  /** A space-separated list of scopes granted to the OAuth application. */
+  scopes?: string
+}
+
+/**
+ * Parameters for completing cross-device OAuth sign in
+ */
+export interface CompleteCrossDeviceOAuthParams {
+  /** The OAuth provider used for the sign in */
+  provider: Provider
+  /** The authorization code from the OAuth provider */
+  code: string
+  /** The state parameter from the OAuth provider */
+  state: string
+}
+
+/**
+ * Response from initiating a cross-device OAuth sign in
+ */
+export interface CrossDeviceOAuthResponse {
+  /** URL to redirect the secondary device to */
+  url: string
+  /** Unique session ID for the cross-device flow */
+  sessionId: string
+}
+
+/**
+ * PKCE session as stored in the database
+ */
+export interface PKCESession {
+  /** Unique session identifier */
+  session_id: string
+  /** When the session expires */
+  expires_at: string
+  /** Code verifier (only returned to admin API) */
+  code_verifier?: string
+}
+
+/**
+ * Parameters for initiating cross-device OTP sign in
+ */
+export interface SignInWithOtpCrossDeviceCredentials {
+  /** The user's email address */
+  email?: string
+  /** The user's phone number */
+  phone?: string
+  options?: {
+    /** If set to false, this method will not create a new user. Defaults to true. */
+    shouldCreateUser?: boolean
+    /**
+     * A custom data object to store the user's metadata.
+     */
+    data?: object
+    /** Verification token received when the user completes the captcha on the site. */
+    captchaToken?: string
+    /** Messaging channel to use (e.g. whatsapp or sms) */
+    channel?: 'sms' | 'whatsapp'
+  }
+}
+
+/**
+ * Parameters for completing cross-device OTP sign in
+ */
+export interface CompleteOtpCrossDeviceParams {
+  /** The unique session ID from the cross-device flow */
+  sessionId: string
+  /** The OTP code sent to the user */
+  token: string
+  /** The type of OTP verification */
+  type: MobileOtpType | EmailOtpType
+}
+
+/**
+ * Response from initiating a cross-device OTP sign in
+ */
+export interface CrossDeviceOtpResponse {
+  /** Unique session ID for the cross-device flow */
+  sessionId: string
+  /** Email or phone where the OTP was sent */
+  destination?: string
+  /** True if the message was successfully sent */
+  messageId?: string | null
+  error: AuthError | null
 }

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -425,4 +425,50 @@ describe('GoTrueAdminApi', () => {
       })
     })
   })
+
+  describe('PKCE Session Management', () => {
+    test('listPKCESessions() should return active PKCE sessions', async () => {
+      const { error, data } = await serviceRoleApiClient.listPKCESessions()
+
+      expect(error).toBeNull()
+      expect(data).not.toBeNull()
+      if (data) {
+        expect(data).toHaveProperty('sessions')
+        expect(Array.isArray(data.sessions)).toBe(true)
+      }
+    })
+
+    test('deletePKCESession() should delete a specific PKCE session', async () => {
+      // First get a list of sessions to find one to delete
+      const { data: sessionsData, error: listError } = await serviceRoleApiClient.listPKCESessions()
+
+      expect(listError).toBeNull()
+      expect(sessionsData).not.toBeNull()
+      if (sessionsData && sessionsData.sessions.length > 0) {
+        // Get the first session to delete
+        const session = sessionsData.sessions[0]
+        expect(session).toHaveProperty('session_id')
+
+        // Delete the session
+        const { data: deleteData, error: deleteError } =
+          await serviceRoleApiClient.deletePKCESession(session.session_id)
+
+        expect(deleteError).toBeNull()
+        expect(deleteData).not.toBeNull()
+        if (deleteData) {
+          expect(deleteData).toHaveProperty('success')
+          expect(deleteData.success).toBe(true)
+        }
+      }
+    })
+
+    test('deletePKCESession() should handle non-existent session ID', async () => {
+      const nonExistentSessionId = 'non-existent-session-id'
+      const { data, error } = await serviceRoleApiClient.deletePKCESession(nonExistentSessionId)
+
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.status).toBe(404)
+    })
+  })
 })

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,6 +1,5 @@
 import { MockServer } from 'jest-mock-server'
-// @ts-ignore
-import fetch from '@supabase/node-fetch'
+import fetch, { Response } from '@supabase/node-fetch'
 import { API_VERSION_HEADER_NAME } from '../src/lib/constants'
 import { AuthUnknownError, AuthApiError, AuthRetryableFetchError } from '../src/lib/errors'
 import { _request, handleError } from '../src/lib/fetch'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

PKCE flow only allows for single device/browser sign in.

## What is the new behavior?

PKCE flow allows for single device/browser sign in still.
PKCE flow also allows for opt-in support for multi device/browser sign in.

## Additional context

If this needs to be updated in the [main supabase repo](https://github.com/supabase/supabase) first, I'll update it also.
[Discussion 15708](https://github.com/orgs/supabase/discussions/15708)

