### PR TITLE
[Draft] Add listSessions and revokeSession methods to GoTrueClient

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1834,12 +1834,15 @@ export default class GoTrueClient {
    * @returns {Promise<{ data: Session[] | null; error: AuthError | null }>} The active sessions and any error encountered.
    */
   async listSessions(): Promise<{ data: Session[] | null; error: AuthError | null }> {
-    await this.initializePromise;
+    await this.initializePromise
     return await this._acquireLock(-1, async () => {
       return await this._useSession(async (result) => {
-        const { data: { session }, error } = result;
-        if (error) return { data: null, error };
-        if (!session) return { data: null, error: new AuthSessionMissingError() };
+        const {
+          data: { session },
+          error,
+        } = result
+        if (error) return { data: null, error }
+        if (!session) return { data: null, error: new AuthSessionMissingError() }
         const { data: sessionsData, error: sessionsError } = await _request(
           this.fetch,
           'GET',
@@ -1849,11 +1852,11 @@ export default class GoTrueClient {
             jwt: session.access_token,
             xform: (r) => r,
           }
-        );
-        if (sessionsError) return { data: null, error: sessionsError };
-        return { data: sessionsData as Session[], error: null };
-      });
-    });
+        )
+        if (sessionsError) return { data: null, error: sessionsError }
+        return { data: sessionsData as Session[], error: null }
+      })
+    })
   }
 
   /**
@@ -1867,12 +1870,15 @@ export default class GoTrueClient {
    * @returns {Promise<{ error: AuthError | null }>} An object containing an error if the revocation fails.
    */
   async revokeSession(sessionId: string): Promise<{ error: AuthError | null }> {
-    await this.initializePromise;
+    await this.initializePromise
     return await this._acquireLock(-1, async () => {
       return await this._useSession(async (result) => {
-        const { data: { session }, error } = result;
-        if (error) return { error };
-        if (!session) return { error: new AuthSessionMissingError() };
+        const {
+          data: { session },
+          error,
+        } = result
+        if (error) return { error }
+        if (!session) return { error: new AuthSessionMissingError() }
         const { error: revokeError } = await _request(
           this.fetch,
           'DELETE',
@@ -1881,16 +1887,16 @@ export default class GoTrueClient {
             headers: this.headers,
             jwt: session.access_token,
           }
-        );
-        if (revokeError) return { error: revokeError };
+        )
+        if (revokeError) return { error: revokeError }
         // If the revoked session is the current one, remove it from storage.
-        const currentSession = session as Session & { id?: string };
+        const currentSession = session as Session & { id?: string }
         if (currentSession.id && currentSession.id === sessionId) {
-          await this._removeSession();
+          await this._removeSession()
         }
-        return { error: null };
-      });
-    });
+        return { error: null }
+      })
+    })
   }
 
   /**


### PR DESCRIPTION
> [!WARNING]
>The required endpoints in the [supabase/auth](https://github.com/supabase/auth/tree/master/internal/api) API have not yet been added, this is currently just a concept related to https://github.com/orgs/supabase/discussions/34340.

## What kind of change does this PR introduce?
This PR adds a new feature to the Supabase Auth JavaScript SDK. It introduces two new public methods — `listSessions()` and `revokeSession(sessionId: string)` — to the `GoTrueClient` class. These methods enhance session management by allowing developers to list all active sessions for the current user and to revoke a specific session.

## What is the current behavior?
Currently, the SDK provides methods for sign-in, sign-out, and token refresh, but it does not expose any functionality for listing or revoking individual user sessions. Developers can only sign out of the current session or all sessions without granular control.

## What is the new behavior?
- **`listSessions()`**: Retrieves all active sessions for the current user via a GET request to the `/sessions` endpoint. It returns a sessions array or an error if the operation fails.
- **`revokeSession(sessionId: string)`**: Revokes a specific session by its session ID through a DELETE request to `/sessions/{sessionId}`. If the revoked session matches the current session, the method also clears it from local storage.

Both methods follow the existing initialization, locking, and error handling patterns in `GoTrueClient`, ensuring consistency and reliability with the rest of the SDK.

## Additional context
This enhancement addresses a common feature request for granular session management similar to what is available in other major platforms. Although this PR does not include new tests, it aligns with the SDK's established code style and behavior. Future iterations may add dedicated tests for these new methods.

## Context
* Related discussion: https://github.com/orgs/supabase/discussions/34340