### PR TITLE
fix: export `processLock` from toplevel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export {
   navigatorLock,
   NavigatorLockAcquireTimeoutError,
   internals as lockInternals,
+  processLock,
 } from './lib/locks'


### PR DESCRIPTION
Process lock was added in #977 but wasn't exported in top-level which made imports hard.