### PR TITLE
fix: add missing `deleted_at` property to `User` interface

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -348,6 +348,7 @@ export interface User {
   is_anonymous?: boolean
   is_sso_user?: boolean
   factors?: Factor[]
+  deleted_at?: string
 }
 
 export interface UserAttributes {


### PR DESCRIPTION
## What kind of change does this PR introduce?
- add missing `deleted_at` property to User interface