### PR TITLE
feat: warn on async subscriber to onAuthStateChange

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1847,6 +1847,14 @@ export default class GoTrueClient {
   ): {
     data: { subscription: Subscription }
   } {
+    if (callback.constructor.name === 'AsyncFunction') {
+      console.warn(
+        'Calling onAuthStateChange with an async function may cause a deadlock.'
+        + '  For a solution please see the docs: ' +
+        'https://supabase.com/docs/reference/javascript/auth-onauthstatechange'
+      )
+    }
+
     const id: string = uuid()
     const subscription: Subscription = {
       id,

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -814,6 +814,34 @@ describe('The auth client can signin with third-party oAuth providers', () => {
     })
   })
 
+  describe('Developers are warned if subscribing with an async function', () => {
+    const originalWarn = console.warn
+    let warnings: any[][] = []
+
+    beforeEach(() => {
+      console.warn = (...args: any[]) => {
+        console.log('WARN', ...args)
+
+        warnings.push(args)
+      }
+    })
+
+    afterEach(() => {
+      console.warn = originalWarn
+      warnings = []
+    })
+
+    test('Subscribing a non-async listener should not log a warning', async () => {
+      authSubscriptionClient.onAuthStateChange(() => console.log('onAuthStateChange was called'))
+      expect(warnings.length).toEqual(0)
+    })
+
+    test('Subscribing an async listener should log a warning', async () => {
+      authSubscriptionClient.onAuthStateChange(async () => console.log('onAuthStateChange was called'))
+      expect(warnings.length).toEqual(1)
+    })
+  })
+
   describe('Sign Up Enabled', () => {
     test('User can sign up', async () => {
       const { email, password } = mockUserCredentials()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature to warn developers that subscribing to onAuthStateChange with an async function might cause problems.

## What is the current behavior?

Currently no warning is issued either when subscribing, or when calling other supabase functions from inside the onAuthStateChange subscriber leading to the supabase-js client silently hanging.  Related issue: https://github.com/supabase/supabase-js/issues/1401

## What is the new behavior?

The new behaviour results in the developer being warned that they have subscribed with an async function.

## Additional context

I couldn't get the tests to run locally so this PR may not be functioning correctly.