### PR TITLE
feat: validate uuid and sign out scope parameters to functions

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,6 +1,6 @@
 import { API_VERSION_HEADER_NAME, BASE64URL_REGEX } from './constants'
 import { AuthInvalidJwtError } from './errors'
-import { base64UrlToUint8Array, stringFromBase64URL, stringToBase64URL } from './base64url'
+import { base64UrlToUint8Array, stringFromBase64URL } from './base64url'
 import { JwtHeader, JwtPayload, SupportedStorage } from './types'
 
 export function expiresAt(expiresIn: number) {
@@ -355,5 +355,13 @@ export function getAlgorithm(alg: 'RS256' | 'ES256'): RsaHashedImportParams | Ec
       }
     default:
       throw new Error('Invalid alg claim')
+  }
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+export function validateUUID(str: string) {
+  if (!UUID_REGEX.test(str)) {
+    throw new Error('@supabase/auth-js: Expected parameter to be UUID but is not')
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1279,3 +1279,6 @@ export interface JWK {
   kid?: string
   [key: string]: any
 }
+
+export const SIGN_OUT_SCOPES = ['global', 'local', 'others'] as const
+export type SignOutScope = typeof SIGN_OUT_SCOPES[number]

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -16,7 +16,7 @@ import {
 import type { GenerateLinkProperties, User } from '../src/lib/types'
 
 const INVALID_EMAIL = 'xx:;x@x.x'
-const INVALID_USER_ID = 'invalid-uuid'
+const NON_EXISTANT_USER_ID = '83fd9e20-7a80-46e4-bf29-a86e3d6bbf66'
 
 describe('GoTrueAdminApi', () => {
   describe('User creation', () => {
@@ -152,7 +152,7 @@ describe('GoTrueAdminApi', () => {
     })
 
     test('getUserById() returns AuthError when user id is invalid', async () => {
-      const { error, data } = await serviceRoleApiClient.getUserById(INVALID_USER_ID)
+      const { error, data } = await serviceRoleApiClient.getUserById(NON_EXISTANT_USER_ID)
 
       expect(error).not.toBeNull()
       expect(data.user).toBeNull()
@@ -283,7 +283,7 @@ describe('GoTrueAdminApi', () => {
     })
 
     test('deleteUser() returns AuthError when user id is invalid', async () => {
-      const { error, data } = await serviceRoleApiClient.deleteUser(INVALID_USER_ID)
+      const { error, data } = await serviceRoleApiClient.deleteUser(NON_EXISTANT_USER_ID)
 
       expect(error).not.toBeNull()
       expect(data.user).toBeNull()
@@ -479,7 +479,7 @@ describe('GoTrueAdminApi', () => {
     test('listUsers() returns AuthError when page is invalid', async () => {
       const { error, data } = await serviceRoleApiClient.listUsers({
         page: -1,
-        perPage: 10
+        perPage: 10,
       })
 
       expect(error).not.toBeNull()
@@ -489,8 +489,8 @@ describe('GoTrueAdminApi', () => {
 
   describe('Update User', () => {
     test('updateUserById() returns AuthError when user id is invalid', async () => {
-      const { error, data } = await serviceRoleApiClient.updateUserById(INVALID_USER_ID, {
-        email: 'new@email.com'
+      const { error, data } = await serviceRoleApiClient.updateUserById(NON_EXISTANT_USER_ID, {
+        email: 'new@email.com',
       })
 
       expect(error).not.toBeNull()
@@ -513,7 +513,7 @@ describe('GoTrueAdminApi', () => {
       expect(uid).toBeTruthy()
 
       const { error: enrollError } = await authClientWithSession.mfa.enroll({
-        factorType: 'totp'
+        factorType: 'totp',
       })
       expect(enrollError).toBeNull()
 
@@ -526,35 +526,41 @@ describe('GoTrueAdminApi', () => {
 
       const factorId = data?.factors[0].id
       expect(factorId).toBeDefined()
-      const { data: deletedData, error: deletedError } = await serviceRoleApiClient.mfa.deleteFactor({ 
-        userId: uid,
-        id: factorId!
-      })
+      const { data: deletedData, error: deletedError } =
+        await serviceRoleApiClient.mfa.deleteFactor({
+          userId: uid,
+          id: factorId!,
+        })
       expect(deletedError).toBeNull()
       expect(deletedData).not.toBeNull()
       const deletedId = (deletedData as any)?.data?.id
       console.log('deletedId:', deletedId)
       expect(deletedId).toEqual(factorId)
 
-      const { data: latestData, error: latestError } = await serviceRoleApiClient.mfa.listFactors({ userId: uid })
+      const { data: latestData, error: latestError } = await serviceRoleApiClient.mfa.listFactors({
+        userId: uid,
+      })
       expect(latestError).toBeNull()
       expect(latestData).not.toBeNull()
       expect(Array.isArray(latestData?.factors)).toBe(true)
       expect(latestData?.factors.length).toEqual(0)
     })
 
-
     test('mfa.listFactors returns AuthError for invalid user', async () => {
-      const { data, error } = await serviceRoleApiClient.mfa.listFactors({ userId: INVALID_USER_ID })
+      const { data, error } = await serviceRoleApiClient.mfa.listFactors({
+        userId: NON_EXISTANT_USER_ID,
+      })
       expect(data).toBeNull()
       expect(error).not.toBeNull()
     })
 
     test('mfa.deleteFactors returns AuthError for invalid user', async () => {
-      const { data, error } = await serviceRoleApiClient.mfa.deleteFactor({ userId: INVALID_USER_ID , id: '1' })
+      const { data, error } = await serviceRoleApiClient.mfa.deleteFactor({
+        userId: NON_EXISTANT_USER_ID,
+        id: NON_EXISTANT_USER_ID,
+      })
       expect(data).toBeNull()
       expect(error).not.toBeNull()
     })
-
   })
 })


### PR DESCRIPTION
You're not supposed to pass non-UUID values for parameters which are meant to be UUID, as well as the sign out scope parameter.