### PR TITLE
fix: handle null current session with split session storage

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2153,9 +2153,9 @@ export default class GoTrueClient {
     this._debug(debugName, 'begin')
 
     try {
-      const currentSession: Session = (await getItemAsync(this.storage, this.storageKey)) as any
+      const currentSession = (await getItemAsync(this.storage, this.storageKey)) as Session | null
 
-      if (this.userStorage) {
+      if (currentSession && this.userStorage) {
         let maybeUser: { user: User | null } | null = (await getItemAsync(
           this.userStorage,
           this.storageKey + '-user'


### PR DESCRIPTION
Due to bad typing the `null` case of a missing session when using the `userStorage` option introduced in #1023 caused a crash.