### PR TITLE
fix: Move @solana/wallet-standard-features to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@solana/wallet-standard-features": "^1.3.0",
         "@supabase/node-fetch": "^2.6.14"
       },
       "devDependencies": {
-        "@solana/wallet-standard-features": "^1.3.0",
         "@types/faker": "^5.1.6",
         "@types/jest": "^28.1.6",
         "@types/jsonwebtoken": "^8.5.6",
@@ -1290,8 +1290,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
       "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0"
@@ -1821,7 +1819,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
       "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -1831,7 +1828,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
       "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
@@ -8443,7 +8439,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
       "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
-      "dev": true,
       "requires": {
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0"
@@ -8877,14 +8872,12 @@
     "@wallet-standard/base": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
-      "dev": true
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ=="
     },
     "@wallet-standard/features": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
       "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
-      "dev": true,
       "requires": {
         "@wallet-standard/base": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "docs:json": "typedoc --json docs/v2/spec.json --excludeExternals --excludePrivate --excludeProtected src/index.ts"
   },
   "dependencies": {
-    "@supabase/node-fetch": "^2.6.14"
+    "@supabase/node-fetch": "^2.6.14",
+    "@solana/wallet-standard-features": "^1.3.0"
   },
   "devDependencies": {
-    "@solana/wallet-standard-features": "^1.3.0",
     "@types/faker": "^5.1.6",
     "@types/jest": "^28.1.6",
     "@types/jsonwebtoken": "^8.5.6",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - corrects dependency classification

## What is the current behavior?

TypeScript compilation fails for users with the error:
```
Cannot find module '@solana/wallet-standard-features' or its corresponding type declarations
```

This happens because `@solana/wallet-standard-features` is imported in `src/lib/types.ts` but is incorrectly placed in `devDependencies`. When users install `@supabase/auth-js`, they don't get dev dependencies, causing the TypeScript compiler to fail when it encounters the missing module.


## What is the new behavior?

TypeScript compilation works correctly. The `@solana/wallet-standard-features` package is now properly classified as a runtime dependency, making it available to all users who install `@supabase/auth-js`.

Users no longer need to manually install the missing dependency as a workaround.

## Additional context
- Closes: #1076 
- No version changes - just moved `@solana/wallet-standard-features: ^1.3.0` from `devDependencies` to `dependencies`
- This fixes the issue for all TypeScript users without affecting functionality
- The package was already being used correctly, just mis-categorized in package.json