### PR TITLE
feat: make `getClaims()` non experimental, add global cache

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,4 +31,4 @@ export const API_VERSIONS = {
 
 export const BASE64URL_REGEX = /^([a-z0-9_-]{4})*($|[a-z0-9_-]{3}$|[a-z0-9_-]{2}$)$/i
 
-export const JWKS_TTL = 600000 // 10 minutes
+export const JWKS_TTL = 10 * 60 * 1000 // 10 minutes


### PR DESCRIPTION
`supabase.auth.getClaims()` loses `@expermental` status. To further improve performance since Vercel have now added Fluid Compute which shares a lot more memory between requests, every client's JWKS cache is stored in a global variable under the client's storage key.