### PR TITLE
feat: fallback to `getUser()` if the `kid` of the JWT is not found

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -340,7 +340,9 @@ export function validateExp(exp: number) {
   }
 }
 
-export function getAlgorithm(alg: 'RS256' | 'ES256'): RsaHashedImportParams | EcKeyImportParams {
+export function getAlgorithm(
+  alg: 'HS256' | 'RS256' | 'ES256'
+): RsaHashedImportParams | EcKeyImportParams {
   switch (alg) {
     case 'RS256':
       return {


### PR DESCRIPTION
Because the `/.well-known/jwks.json` is heavily cached, a developer may rotate the standby key to in use faster than those caches expire. In that case the `getClaims()` method may receive a JWT signed with a key ID it doesn't recognize. Instead of failing with an error, it should reach out directly to the Auth server to verify the JWT.