### PR TITLE
fix: use JSON-based deep clone instead of structuredClone

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -112,6 +112,7 @@ import type {
   Web3Credentials,
 } from './lib/types'
 import { stringToUint8Array, bytesToBase64URL } from './lib/base64url'
+import { deepClone } from './lib/helpers'
 
 polyfillGlobalThis() // Make "globalThis" available
 
@@ -2419,13 +2420,13 @@ export default class GoTrueClient {
       const mainSessionData: Omit<Session, 'user'> & { user?: User } = { ...sessionToProcess }
       delete mainSessionData.user // Remove user (real or proxy) before cloning for main storage
 
-      const clonedMainSessionData = structuredClone(mainSessionData)
+      const clonedMainSessionData = deepClone(mainSessionData)
       await setItemAsync(this.storage, this.storageKey, clonedMainSessionData)
     } else {
       // No userStorage is configured.
       // In this case, session.user should ideally not be a proxy.
       // If it were, structuredClone would fail. This implies an issue elsewhere if user is a proxy here
-      const clonedSession = structuredClone(sessionToProcess) // sessionToProcess still has its original user property
+      const clonedSession = deepClone(sessionToProcess) // sessionToProcess still has its original user property
       await setItemAsync(this.storage, this.storageKey, clonedSession)
     }
   }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -408,8 +408,8 @@ export function userNotAvailableProxy(): User {
 
 /**
  * Deep clones a JSON-serializable object using JSON.parse(JSON.stringify(obj)).
- * Note: Only works for JSON-safe data (no functions, Dates, Maps, Sets, etc.)
+ * Note: Only works for JSON-safe data.
  */
 export function deepClone<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(JSON.stringify(obj))
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -405,3 +405,11 @@ export function userNotAvailableProxy(): User {
     },
   })
 }
+
+/**
+ * Deep clones a JSON-serializable object using JSON.parse(JSON.stringify(obj)).
+ * Note: Only works for JSON-safe data (no functions, Dates, Maps, Sets, etc.)
+ */
+export function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
Not all JS runtimes support `structuredClone` (introduced in https://github.com/supabase/auth-js/pull/1023). (Example: https://github.com/supabase/supabase-js/issues/1504) 

- As the session data is safe to JSON serialize, replace `structuredClone` use with JSON de/serialize.
- Added the helper function to increase the readability (making the intent clear).
