### PR TITLE
fix: correct typo in GoTrueClient initializePromise comment

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -210,7 +210,7 @@ export default class GoTrueClient {
   /**
    * Keeps track of the async client initialization.
    * When null or not yet resolved the auth state is `unknown`
-   * Once resolved the the auth state is known and it's save to call any further client methods.
+   * Once resolved the auth state is known and it's safe to call any further client methods.
    * Keep extra care to never reject or throw uncaught errors
    */
   protected initializePromise: Promise<InitializeResult> | null = null


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes a minor typo in a code comment.

## What is the current behavior?
The comment contains a few typos. Please refer to the file changes for details.

## What is the new behavior?
The typos in the comment have been corrected. Please refer to the file changes.

## Additional context
This is a minor typo fix in a code comment. No functional changes, so I opened a PR directly without an Issue. Please let me know if you'd prefer a separate Issue as well.