### PR TITLE
chore: do not fail on coveralls error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
           npm t
 
       - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
+          fail-on-error: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./test/coverage/lcov.info
           base-path: ./src


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a `fail-on-error: false` to `coveralls` uploads. Change `coverageapp` version used from `master` to `v2`, so that it accepts this input.

## What is the current behavior?

Coveralls seems to be failing, and being flaky. 

## What is the new behavior?

If `coveralls` upload fails, the CI will not fail.